### PR TITLE
Feature cover updates

### DIFF
--- a/src/component/CoverComponent.ts
+++ b/src/component/CoverComponent.ts
@@ -8,6 +8,7 @@ import {Container, Navigator} from "../Viewer";
 import {ICoverConfiguration, IComponentConfiguration, ComponentService, Component} from "../Component";
 
 import {IVNodeHash} from "../Render";
+import {Settings} from "../Utils";
 
 export class CoverComponent extends Component {
     public static componentName: string = "cover";
@@ -81,7 +82,7 @@ export class CoverComponent extends Component {
     private _getCoverBackgroundVNode(conf: ICoverConfiguration): vd.VNode {
         let url: string = conf.src != null ?
             `url(${conf.src})` :
-            `url(https://d1cuyjsrcm0gby.cloudfront.net/${conf.key}/thumb-320.jpg)`;
+            `url(https://d1cuyjsrcm0gby.cloudfront.net/${conf.key}/thumb-${Settings.coverImageSize}.jpg)`;
 
         return vd.h("div.CoverBackground", { style: { backgroundImage: url } }, []);
     }

--- a/src/utils/Settings.ts
+++ b/src/utils/Settings.ts
@@ -5,6 +5,7 @@ export class Settings {
     private static _baseImageSize: number;
     private static _basePanoramaSize: number;
     private static _maxImageSize: number;
+    private static _coverImageSize: number;
 
     public static setOptions(options: IViewerOptions): void {
         Settings._baseImageSize = options.baseImageSize != null ?
@@ -18,6 +19,10 @@ export class Settings {
         Settings._maxImageSize = options.maxImageSize != null ?
             options.maxImageSize :
             ImageSize.Size2048;
+
+        Settings._coverImageSize = options.coverImageSize != null ?
+            options.coverImageSize :
+            ImageSize.Size320;
     }
 
     public static get baseImageSize(): number {
@@ -30,6 +35,10 @@ export class Settings {
 
     public static get maxImageSize(): number {
         return Settings._maxImageSize;
+    }
+
+    public static get coverImageSize(): number {
+        return Settings._coverImageSize;
     }
 }
 

--- a/src/viewer/interfaces/IViewerOptions.ts
+++ b/src/viewer/interfaces/IViewerOptions.ts
@@ -141,6 +141,12 @@ export interface IViewerOptions {
     maxImageSize?: ImageSize;
 
     /**
+     * Default size of the thumbnail used on the cover
+     * @default {ImageSize.Size320}
+     */
+    coverImageSize?: ImageSize;
+
+    /**
      * The render mode in the viewer.
      * @default {RenderMode.Letterbox}
      */

--- a/styles/CoverComponent.css
+++ b/styles/CoverComponent.css
@@ -219,13 +219,13 @@
     transition: all ease-in-out 250ms, filter ease-in-out 100ms;
     filter: blur(3px);
     position: absolute;
-    top: -50px;
-    right: -50px;
-    bottom: -50px;
-    left: -50px;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     background-size: cover;
+    background-position: center;
     z-index: -10;
-
 }
 
 .Cover:hover .CoverBackground {

--- a/styles/CoverComponent.css
+++ b/styles/CoverComponent.css
@@ -212,7 +212,7 @@
     z-index: 20;
     overflow: hidden;
     cursor: pointer;
-    transition: visibility linear 500ms;
+    transition: opacity .2s ease-in-out;
 }
 
 .CoverBackground {
@@ -242,6 +242,7 @@
 
 .CoverDone {
     visibility: hidden;
+    opacity: 0;
 }
 
 .CoverButton {


### PR DESCRIPTION
Hello,

In this PR there are 3 changes:
* Cover image is centered (for issue https://github.com/mapillary/mapillary-js/issues/119)
* Option `coverImageSize` is added to list of options, sets the size of the image used on cover (defaults to currently used size `320`)
* Smoother transition from cover to viewer (a proposal for issue https://github.com/mapillary/mapillary-js/issues/118). Introduces simple opacity transition for the cover component.

The changes are in separate commits so can be added independently.
Looking forward for your feedback!