### PR TITLE
Some documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MapillaryJS is a JavaScript & WebGL library that renders street level photos fro
 
 ## Using MapillaryJS
 
-To use MapillaryJS you must [create an account](http://www.mapillary.com/map/signup) and then [obtain a Client ID](http://www.mapillary.com/map/settings/integrations). Then you can use MapillaryJS with a `<script>` tag.
+To use MapillaryJS you must [create an account](https://www.mapillary.com/signup) and then [obtain a Client ID](https://www.mapillary.com/app/settings/developers). Then you can use MapillaryJS with a `<script>` tag.
 
 ```html
 <!DOCTYPE html>

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -88,7 +88,7 @@ export class Viewer extends EventEmitter {
      *
      * @param {EdgeDirection} dir - Direction towards which to move
      * @example
-     * `viewer.moveToDir(Mapillary.EdgeDirection.NEXT);`
+     * `viewer.moveDir(Mapillary.EdgeDirection.Next);`
      */
     public moveDir(dir: EdgeDirection): when.Promise<Node> {
         return when.promise<Node>((resolve: any, reject: any): void => {


### PR DESCRIPTION
Hello,

This PR addresses two errors in the documentation:

1. The links to Mapillary signup and "obtain a Client ID" pages are out-dated and lead to a 404 page. Updated them to the new URL.

2. The example for `moveDir` was incorrect and was updated to correctly show how the command can be used.