### PR TITLE
Build minified versions with compression and mangling

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "build-dev": "browserify src/Mapillary.ts --plugin tsify --transform brfs --standalone Mapillary --debug | exorcist dist/mapillary-js.js.map > dist/mapillary-js.js",
     "build-watch": "watchify src/Mapillary.ts --plugin tsify --transform brfs --standalone Mapillary --debug -v -o 'exorcist dist/mapillary-js.js.map > dist/mapillary-js.js'",
     "build-docs": "typedoc --mode file --target ES5 --module commonjs --theme default --excludeExternals --name MapillaryJS --out docs/",
-    "build-min": "browserify src/Mapillary.ts --plugin tsify --transform brfs --standalone Mapillary | uglifyjs > dist/mapillary-js.min.js",
+    "build-min": "browserify src/Mapillary.ts --plugin tsify --transform brfs --standalone Mapillary | uglifyjs -c -m > dist/mapillary-js.min.js",
     "clean": "npm run clean-dist && npm run clean-typings",
     "clean-dist": "rm -rf dist && mkdir dist",
     "clean-typings": "rm -rf typings/modules && rm -rf typings/globals && rm -f typings/index.d.ts",


### PR DESCRIPTION
This brings built versions of Mapillary JS from 1.5MB to 1.1MB: by default uglify-js doesn't mangle internal names or do any compressions, it only strips whitespace. Including the options lets it do more efficient compacting.