### PR TITLE
Add 'lookAt' API

### DIFF
--- a/src/api/interfaces/IAPISearchIm.ts
+++ b/src/api/interfaces/IAPISearchIm.ts
@@ -1,0 +1,42 @@
+/**
+ * Interface that describes the raw image response
+ * from search API.
+ */
+export interface IAPISearchIm {
+    /**
+     * Angle of the image shot in degrees between 0 to 360
+     */
+    ca?: number;
+
+    /**
+     * Time image was captured in EPOCH ms
+     */
+    captured_at?: number;
+
+    /**
+     * Key of the image
+     */
+    key: string;
+
+    /**
+     * Longitude of image
+     */
+    lon?: number;
+
+    /**
+     * Latitude of image
+     */
+    lat?: number;
+
+    /**
+     * String representation of where image was shot
+     */
+    location?: string;
+
+    /**
+     * Username of user who uploaded the image
+     */
+    user?: string;
+}
+
+export default IAPISearchIm;

--- a/src/api/interfaces/IAPISearchIms.ts
+++ b/src/api/interfaces/IAPISearchIms.ts
@@ -1,0 +1,22 @@
+import IAPISearchIm from "./IAPISearchIm";
+
+/**
+ * Interface that describes the raw images response
+ * from the API.
+ *
+ * @interface IAPISearchIms
+ */
+
+export interface IAPISearchIms {
+    /**
+     * True if there are more images in pagination false if not.
+     */
+    more: boolean;
+
+    /**
+     * List of raw image response
+     */
+    ims: Array<IAPISearchIm>;
+}
+
+export default IAPISearchIms;

--- a/src/api/interfaces/interfaces.ts
+++ b/src/api/interfaces/interfaces.ts
@@ -2,5 +2,6 @@ export {IAPINavIm} from "./IAPINavIm";
 export {IAPINavImIm} from "./IAPINavImIm";
 export {IAPINavImS} from "./IAPINavImS";
 export {IAPISGet} from "./IAPISGet";
+export {IAPISearchIms} from "./IAPISearchIms";
 export {IAPISearchImClose2} from "./IAPISearchImClose2";
 export {IGPano} from "./IGPano";

--- a/src/viewer/Navigator.ts
+++ b/src/viewer/Navigator.ts
@@ -12,7 +12,7 @@ import "rxjs/add/operator/first";
 import "rxjs/add/operator/map";
 import "rxjs/add/operator/mergeMap";
 
-import {IAPISearchImClose2, APIv2, APIv3} from "../API";
+import {IAPISearchImClose2, IAPISearchIms, APIv2, APIv3} from "../API";
 import {ILatLon} from "../Geo";
 import {GraphService, Node} from "../Graph";
 import {EdgeDirection} from "../Edge";
@@ -93,6 +93,21 @@ export class Navigator {
                     return data.key == null ?
                         Observable.throw<Node>(new Error("no Image found")) :
                         this.moveToKey(data.key);
+                })
+            .first();
+    }
+
+    public lookAt(lat: number, lon: number): Observable<Node> {
+        let searchString: string = `?max_lat=${lat}&max_lon=${lon}&min_lat=${lat}&min_lon=${lon}`;
+        this.loadingService.startLoading("navigator");
+        this._latLonRequested$.next({lat: lat, lon: lon});
+        return Observable
+            .fromPromise(this.apiV2.search.im.callSearchIm(searchString))
+            .mergeMap<Node>(
+                ({ims}: IAPISearchIms): Observable<Node> => {
+                    return ims.length && typeof ims[0] !== "undefined"
+                        ? this.moveToKey(ims[0].key)
+                        : Observable.throw<Node>(new Error("no Image found"));
                 })
             .first();
     }

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -158,6 +158,29 @@ export class Viewer extends EventEmitter {
     }
 
     /**
+     * Move to image that actually is looking at the
+     * given latitude and longitude.
+     *
+     * @param {Number} lat - Latitude, in degrees.
+     * @param {Number} lon - Longitude, in degrees.
+     * @returns {Promise<Node>} Promise to the node that was navigatged to.
+     */
+
+    public lookAt(lat: number, lon: number): when.Promise<Node> {
+        this.activateComponent("loading");
+        return when.promise<Node>((resolve: any, reject: any): void => {
+            this._navigator.lookAt(lat, lon).subscribe(
+                (node: Node): void => {
+                    resolve(node);
+                },
+                (error: Error): void => {
+                    reject(error);
+                }
+            );
+        });
+    }
+
+    /**
      * Detect the viewer's new width and height and resize it.
      *
      * @description The components will also detect the viewer's

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -167,7 +167,6 @@ export class Viewer extends EventEmitter {
      */
 
     public lookAt(lat: number, lon: number): when.Promise<Node> {
-        this.activateComponent("loading");
         return when.promise<Node>((resolve: any, reject: any): void => {
             this._navigator.lookAt(lat, lon).subscribe(
                 (node: Node): void => {


### PR DESCRIPTION
Hi,

This PR includes new API function – `lookAt` see #156 for more details

It is not absolutely clear how to implement this method regarding [the API](https://a.mapillary.com/#search-search). Exploring the API and the codebase I believe that there are two ways to do so:
1. Just do the same as in `moveCloseTo` but without  touching `navigator`;
2. Try to use `/search/im/` [endpoint](https://a.mapillary.com/#get-searchim) to get exact image by coordinates.

I guess that my assumptions are could be wrong and maybe existed the more accurate way to implement `lookAt` method. If so, I hope we can do it by reviewing this PR :)

Please, review.
