### PR TITLE
Fix autoprefixer browser settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,13 @@
     "falcor": "./node_modules/falcor/dist/falcor.browser.min.js",
     "three": "./node_modules/three/build/three.min.js"
   },
+  "browserlist": [
+    "last 2 versions",
+    "safari 7",
+    "ie 11"
+  ],
   "scripts": {
-    "build-css": "cat styles/*.css | postcss --use autoprefixer --autoprefixer.browsers 'last 2 versions, safari 7, ie 11' --use cssnano -o dist/mapillary.min.css",
+    "build-css": "cat styles/*.css | postcss --use autoprefixer --use cssnano -o dist/mapillary.min.css",
     "build-dev": "browserify src/Mapillary.ts --plugin tsify --transform brfs --standalone Mapillary --debug | exorcist dist/mapillary.js.map > dist/mapillary.js",
     "build-watch": "watchify src/Mapillary.ts --plugin tsify --transform brfs --standalone Mapillary --debug -v -o 'exorcist dist/mapillary.js.map > dist/mapillary.js'",
     "build-docs": "typedoc --tsconfig tsconfig.docs.json --mode file --theme default --excludePrivate --excludeExternals --name MapillaryJS --out docs/",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "falcor": "./node_modules/falcor/dist/falcor.browser.min.js",
     "three": "./node_modules/three/build/three.min.js"
   },
-  "browserlist": [
+  "browserslist": [
     "last 2 versions",
     "safari 7",
     "ie 11"


### PR DESCRIPTION
The postcss-cli `--autoprefixer.browsers` parameter was removed a while ago ([ref](https://github.com/postcss/postcss-cli/blob/master/CHANGELOG.md#changes-since-v260)).

Note that the current release is missing prefixes as a result(for Safari 7 support).

 