### PR TITLE
fix(slider): add CSS style for IE pseudo-classes

### DIFF
--- a/styles/SliderComponent.css
+++ b/styles/SliderComponent.css
@@ -46,6 +46,37 @@
     appearance: none;
 }
 
+.SliderControl::-ms-track {
+    background-color: transparent;
+    border-color: transparent;
+    border-radius: 999px;
+    box-sizing: border-box;
+    color: transparent;    
+    cursor: pointer;
+    display: block;
+    height: 30px;
+    margin: 0 auto;
+    max-width: 60%;
+    padding: 4px;
+    pointer-events: auto;    
+    width: 100%;
+}
+
+.SliderControl::-ms-thumb {
+    background: #474A4E;
+    border: 2px solid white;
+    border-radius: 999px;
+    box-shadow: 0px 2px 4px 0px rgba(0,0,0,0.50);
+    height: 22px;
+    width: 22px;
+}
+
+.SliderControl::-ms-fill-lower,
+.SliderControl::-ms-fill-upper,
+.SliderControl::-ms-tooltip {
+    display: none;
+}
+
 .SliderControl:focus {
     outline: none;
 }


### PR DESCRIPTION
This PR fixes the appearance of the `slider` component in IE11. Currently it looks like the default `range` input and this PR adds additional CSS using IE-specific pseudo-classes to bring the appearance in line with how it looks on other browsers.

Tested on IE11 and Windows 8.1, please test it on more recent versions of IE and Windows as well.