### PR TITLE
refactor: use mapillary domains instead of cloudfront urls

### DIFF
--- a/src/utils/Urls.ts
+++ b/src/utils/Urls.ts
@@ -2,11 +2,11 @@ import {IUrlOptions} from "../Viewer";
 
 export class Urls {
     private static _apiHost: string = "a.mapillary.com";
-    private static _atomicReconstructionHost: string = "d3necqxnn15whe.cloudfront.net";
+    private static _atomicReconstructionHost: string = "atomic-reconstructions.mapillary.com";
     private static _exploreHost: string = "www.mapillary.com";
-    private static _imageHost: string = "d1cuyjsrcm0gby.cloudfront.net";
-    private static _imageTileHost: string = "d2qb1440i7l50o.cloudfront.net";
-    private static _meshHost: string = "d1brzeo354iq2l.cloudfront.net";
+    private static _imageHost: string = "images.mapillary.com";
+    private static _imageTileHost: string = "loris.mapillary.com";
+    private static _meshHost: string = "meshes.mapillary.com";
     private static _origin: string = "mapillary.webgl";
     private static _scheme: string = "https";
 

--- a/src/viewer/interfaces/IUrlOptions.ts
+++ b/src/viewer/interfaces/IUrlOptions.ts
@@ -19,7 +19,7 @@ export interface IUrlOptions {
      * @description Used for retrieving the atomic reconstruction
      * for showing point clouds.
      *
-     * @default {"d3necqxnn15whe.cloudfront.net"}
+     * @default {"atomic-reconstructions.mapillary.com"}
      */
     atomicReconstructionHost?: string;
 
@@ -38,7 +38,7 @@ export interface IUrlOptions {
      *
      * @description Used for retrieving image thumbnails.
      *
-     * @default {"d1cuyjsrcm0gby.cloudfront.net"}
+     * @default {"images.mapillary.com"}
      */
     imageHost?: string;
 
@@ -48,7 +48,7 @@ export interface IUrlOptions {
      * @description Used for retrieving high resolution
      * image tiles when zooming.
      *
-     * @default {"d2qb1440i7l50o.cloudfront.net"}
+     * @default {"loris.mapillary.com"}
      */
     imageTileHost?: string;
 
@@ -58,7 +58,7 @@ export interface IUrlOptions {
      * @description Used for retriving a 3D mesh for
      * each image.
      *
-     * @default {"d1brzeo354iq2l.cloudfront.net"}
+     * @default {"meshes.mapillary.com"}
      */
     meshHost?: string;
 


### PR DESCRIPTION
I've setup cloudfront with distributions that use our mapillary.com domain so we add more flexibility for those in the future. (Previous urls will not stop working but we want new clones to use these instead).