### PR TITLE
Disable play functionality in earth mode

### DIFF
--- a/spec/component/sequence/SequenceComponent.spec.ts
+++ b/spec/component/sequence/SequenceComponent.spec.ts
@@ -1,5 +1,5 @@
 
-import {of as observableOf, Observable, ReplaySubject, Subject, VirtualTimeScheduler} from "rxjs";
+import { of as observableOf, Observable, ReplaySubject, Subject, VirtualTimeScheduler } from "rxjs";
 
 import {
     SequenceComponent,
@@ -11,16 +11,17 @@ import {
     Node,
     Sequence,
 } from "../../../src/Graph";
-import {ISize} from "../../../src/Render";
+import { ISize } from "../../../src/Render";
 import {
     Container,
     Navigator,
 } from "../../../src/Viewer";
 
-import {ContainerMockCreator} from "../../helper/ContainerMockCreator.spec";
-import {MockCreator} from "../../helper/MockCreator.spec";
-import {NavigatorMockCreator} from "../../helper/NavigatorMockCreator.spec";
-import {NodeHelper} from "../../helper/NodeHelper.spec";
+import { ContainerMockCreator } from "../../helper/ContainerMockCreator.spec";
+import { MockCreator } from "../../helper/MockCreator.spec";
+import { NavigatorMockCreator } from "../../helper/NavigatorMockCreator.spec";
+import { NodeHelper } from "../../helper/NodeHelper.spec";
+import State from "../../../src/state/State";
 
 describe("SequenceComponent.ctor", () => {
     it("should be defined", () => {
@@ -273,6 +274,7 @@ describe("SequenceComponent.activate", () => {
         const component: SequenceComponent = createComponent();
         component.activate();
 
+        (<Subject<State>>navigatorMock.stateService.state$).next(State.Traversing);
         (<Subject<number>>navigatorMock.playService.speed$).next(1);
         (<Subject<ISize>>containerMock.renderService.size$).next({ height: 1, width: 1 });
 
@@ -305,6 +307,7 @@ describe("SequenceComponent.activate", () => {
         const component: SequenceComponent = createComponent();
         component.activate();
 
+        (<Subject<State>>navigatorMock.stateService.state$).next(State.Traversing);
         (<Subject<number>>navigatorMock.playService.speed$).next(1);
         (<Subject<ISize>>containerMock.renderService.size$).next({ height: 1, width: 1 });
 
@@ -344,6 +347,7 @@ describe("SequenceComponent.activate", () => {
         const component: SequenceComponent = createComponent();
         component.activate();
 
+        (<Subject<State>>navigatorMock.stateService.state$).next(State.Traversing);
         (<Subject<number>>navigatorMock.playService.speed$).next(1);
         (<Subject<ISize>>containerMock.renderService.size$).next({ height: 1, width: 1 });
 
@@ -397,6 +401,7 @@ describe("SequenceComponent.activate", () => {
         const component: SequenceComponent = createComponent();
         component.activate();
 
+        (<Subject<State>>navigatorMock.stateService.state$).next(State.Traversing);
         (<Subject<number>>navigatorMock.playService.speed$).next(1);
         (<Subject<ISize>>containerMock.renderService.size$).next({ height: 1, width: 1 });
 
@@ -462,6 +467,7 @@ describe("SequenceComponent.activate", () => {
         const component: SequenceComponent = createComponent();
         component.activate();
 
+        (<Subject<State>>navigatorMock.stateService.state$).next(State.Traversing);
         (<Subject<number>>navigatorMock.playService.speed$).next(1);
         (<Subject<ISize>>containerMock.renderService.size$).next({ height: 1, width: 1 });
 
@@ -511,6 +517,7 @@ describe("SequenceComponent.activate", () => {
         const component: SequenceComponent = createComponent();
         component.activate();
 
+        (<Subject<State>>navigatorMock.stateService.state$).next(State.Traversing);
         (<Subject<number>>navigatorMock.playService.speed$).next(1);
         (<Subject<ISize>>containerMock.renderService.size$).next({ height: 1, width: 1 });
 

--- a/spec/viewer/PlayService.spec.ts
+++ b/spec/viewer/PlayService.spec.ts
@@ -276,6 +276,23 @@ describe("PlayService.play", () => {
         expect(stopSpy.calls.count()).toBe(1);
     });
 
+    it("should stop if earth mode is emitted", () => {
+        const playService: PlayService = new PlayService(graphService, stateService);
+
+        const stopSpy: jasmine.Spy = spyOn(playService, "stop").and.callThrough();
+        spyOn(graphService, "cacheSequence$").and.returnValue(new Subject<Sequence>());
+        spyOn(graphService, "cacheSequenceNodes$").and.returnValue(new Subject<Sequence>());
+        spyOn(graphService, "cacheBoundingBox$").and.returnValue(observableOf([]));
+
+        playService.setDirection(EdgeDirection.Next);
+
+        playService.play();
+
+        (<Subject<State>>stateService.state$).next(State.Earth);
+
+        expect(stopSpy.calls.count()).toBe(1);
+    });
+
     it("should stop if error occurs", () => {
         spyOn(console, "error").and.stub();
 

--- a/src/component/sequence/SequenceDOMRenderer.ts
+++ b/src/component/sequence/SequenceDOMRenderer.ts
@@ -1,6 +1,6 @@
-import {merge as observableMerge, Observable, Subject, Subscription} from "rxjs";
+import { merge as observableMerge, Observable, Subject, Subscription } from "rxjs";
 
-import {filter} from "rxjs/operators";
+import { filter } from "rxjs/operators";
 import * as vd from "virtual-dom";
 
 import {
@@ -8,13 +8,13 @@ import {
     ISequenceConfiguration,
     SequenceComponent,
 } from "../../Component";
-import {EdgeDirection} from "../../Edge";
-import {AbortMapillaryError} from "../../Error";
+import { EdgeDirection } from "../../Edge";
+import { AbortMapillaryError } from "../../Error";
 import {
     IEdgeStatus,
     Node,
 } from "../../Graph";
-import {ISize} from "../../Render";
+import { ISize } from "../../Render";
 import {
     Container,
     Navigator,
@@ -102,12 +102,12 @@ export class SequenceDOMRenderer {
         }
 
         this._changingSubscription = observableMerge(
-                this._container.mouseService.documentMouseUp$,
-                this._container.touchService.touchEnd$.pipe(
-                    filter(
-                        (touchEvent: TouchEvent): boolean => {
-                            return touchEvent.touches.length === 0;
-                        })))
+            this._container.mouseService.documentMouseUp$,
+            this._container.touchService.touchEnd$.pipe(
+                filter(
+                    (touchEvent: TouchEvent): boolean => {
+                        return touchEvent.touches.length === 0;
+                    })))
             .subscribe(
                 (event: Event): void => {
                     if (this._changingSpeed) {
@@ -141,6 +141,7 @@ export class SequenceDOMRenderer {
         speed: number,
         index: number,
         max: number,
+        playEnabled: boolean,
         component: SequenceComponent,
         navigator: Navigator): vd.VNode {
 
@@ -149,7 +150,13 @@ export class SequenceDOMRenderer {
         }
 
         const stepper: vd.VNode =
-            this._createStepper(edgeStatus, configuration, containerWidth, component, navigator);
+            this._createStepper(
+                edgeStatus,
+                configuration,
+                playEnabled,
+                containerWidth,
+                component,
+                navigator);
         const controls: vd.VNode = this._createSequenceControls(containerWidth);
         const playback: vd.VNode = this._createPlaybackControls(containerWidth, speed, component, configuration);
         const timeline: vd.VNode = this._createTimelineControls(containerWidth, index, max);
@@ -334,11 +341,14 @@ export class SequenceDOMRenderer {
     private _createPlayingButton(
         nextKey: string,
         prevKey: string,
+        playEnabled: boolean,
         configuration: ISequenceConfiguration,
         component: SequenceComponent): vd.VNode {
 
-        let canPlay: boolean = configuration.direction === EdgeDirection.Next && nextKey != null ||
-            configuration.direction === EdgeDirection.Prev && prevKey != null;
+        let canPlay: boolean =
+            (configuration.direction === EdgeDirection.Next && nextKey != null) ||
+            (configuration.direction === EdgeDirection.Prev && prevKey != null);
+        canPlay = canPlay && playEnabled;
 
         let onclick: (e: Event) => void = configuration.playing ?
             (e: Event): void => { component.stop(); } :
@@ -483,10 +493,11 @@ export class SequenceDOMRenderer {
     private _createStepper(
         edgeStatus: IEdgeStatus,
         configuration: ISequenceConfiguration,
+        playEnabled: boolean,
         containerWidth: number,
         component: SequenceComponent,
         navigator: Navigator,
-        ): vd.VNode {
+    ): vd.VNode {
 
         let nextKey: string = null;
         let prevKey: string = null;
@@ -501,7 +512,8 @@ export class SequenceDOMRenderer {
             }
         }
 
-        const playingButton: vd.VNode = this._createPlayingButton(nextKey, prevKey, configuration, component);
+        const playingButton: vd.VNode = this._createPlayingButton(
+            nextKey, prevKey, playEnabled, configuration, component);
         const buttons: vd.VNode[] = this._createSequenceArrows(nextKey, prevKey, containerWidth, configuration, navigator);
         buttons.splice(1, 0, playingButton);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Earth mode does not support playing functionality.

## Contribution

- Disables key command and buttons for playing in earth mode. 
- Stops playing when switching to earth mode

## Test Plan

`yarn test`
