### PR TITLE
Spatial option for original position altitude

### DIFF
--- a/debug/spatial.html
+++ b/debug/spatial.html
@@ -43,17 +43,27 @@
             spatial.defaultConfiguration,
             { imagesVisible: true });
 
-        const mode = Mapillary.SpatialDataComponent.CameraVisualizationMode;
-        const none = mode.Default;
-        const cluster = mode.Cluster;
-        const connectedComponent = mode.ConnectedComponent;
-        const sequence = mode.Sequence;
+        const camMode = Mapillary.SpatialDataComponent.CameraVisualizationMode;
+        const none = camMode.Default;
+        const cluster = camMode.Cluster;
+        const connectedComponent = camMode.ConnectedComponent;
+        const sequence = camMode.Sequence;
 
-        const modeRotation = {};
-        modeRotation[none] = cluster;
-        modeRotation[cluster] = connectedComponent;
-        modeRotation[connectedComponent] = sequence;
-        modeRotation[sequence] = none;
+        const camModeRotation = {};
+        camModeRotation[none] = cluster;
+        camModeRotation[cluster] = connectedComponent;
+        camModeRotation[connectedComponent] = sequence;
+        camModeRotation[sequence] = none;
+
+        const posMode = Mapillary.SpatialDataComponent.OriginalPositionMode;
+        const hidden = posMode.Hidden;
+        const flat = posMode.Flat;
+        const altitude = posMode.Altitude;
+
+        const posModeRotation = {};
+        posModeRotation[hidden] = flat;
+        posModeRotation[flat] = altitude;
+        posModeRotation[altitude] = hidden;
 
         function toggleImages() {
             s.imagesVisible = !s.imagesVisible;
@@ -62,8 +72,15 @@
         }
 
         function rotateCvm() {
-            s.cameraVisualizationMode = modeRotation[s.cameraVisualizationMode];
+            s.cameraVisualizationMode =
+                camModeRotation[s.cameraVisualizationMode];
             configure("cameraVisualizationMode");
+        }
+
+        function rotatePm() {
+            s.originalPositionMode =
+                posModeRotation[s.originalPositionMode];
+            configure("originalPositionMode");
         }
 
         function toggleBooleanSetting(name) {
@@ -105,10 +122,10 @@
                     case 'c': name = 'camerasVisible'; break;
                     case 'e': name = 'earthControls'; break;
                     case 'p': name = 'pointsVisible'; break;
-                    case 'o': name = 'positionsVisible'; break;
                     case 't': name = 'tilesVisible'; break;
                     case 'i': toggleImages(); break;
                     case 'v': rotateCvm(); break;
+                    case 'o': rotatePm(); break;
                     case 'q': changeSize('pointSize', 0.9); break;
                     case 'w': changeSize('pointSize', 1.1); break;
                     case 'a': changeSize('cameraSize', 0.9); break;

--- a/src/api/FalcorDataProvider.ts
+++ b/src/api/FalcorDataProvider.ts
@@ -204,6 +204,7 @@ export class FalcorDataProvider extends DataProviderBase {
         ];
 
         this._propertiesSpatial = [
+            "altitude",
             "atomic_scale",
             "cluster_key",
             "c_rotation",

--- a/src/api/interfaces/IFillNode.ts
+++ b/src/api/interfaces/IFillNode.ts
@@ -9,6 +9,11 @@ import INodeUrls from "./INodeUrls";
  */
 export interface IFillNode extends INodeUrls {
     /**
+     * Original EXIF altitude above sea level, in meters.
+     */
+    altitude?: number;
+
+    /**
      * Scale of atomic reconstruction.
      */
     atomic_scale?: number;

--- a/src/component/interfaces/ISpatialDataConfiguration.ts
+++ b/src/component/interfaces/ISpatialDataConfiguration.ts
@@ -1,5 +1,6 @@
 import { IComponentConfiguration } from "../../Component";
-import { CameraVisualizationMode } from "../spatialdata/SpatialDataExport";
+import CameraVisualizationMode from "../spatialdata/CameraVisualizationMode";
+import OriginalPositionMode from "../spatialdata/OriginalPositionMode";
 
 /**
  * Interface for configuration of spatial data component.
@@ -40,6 +41,7 @@ export interface ISpatialDataConfiguration extends IComponentConfiguration {
      * @default false
      */
     camerasVisible?: boolean;
+
     /**
      * Specify the camera visualization mode.
      *
@@ -65,6 +67,16 @@ export interface ISpatialDataConfiguration extends IComponentConfiguration {
     earthControls?: boolean;
 
     /**
+     * Specify the original position visualization mode.
+     *
+     * @description The original positions are hidden
+     * by default.
+     *
+     * @default OriginalPositionMode.Hidden
+     */
+    originalPositionMode?: OriginalPositionMode;
+
+    /**
      * The point size on the interval [0.01, 1].
      *
      * @default 0.1
@@ -79,9 +91,8 @@ export interface ISpatialDataConfiguration extends IComponentConfiguration {
     pointsVisible?: boolean;
 
     /**
-     * Specify if the original GPS positions should be visible or not.
-     *
-     * @default false
+     * @deprecated Deprecated since v3.1.0. Use originalPositionMode
+     * property instead.
      */
     positionsVisible?: boolean;
 

--- a/src/component/spatialdata/OriginalPositionMode.ts
+++ b/src/component/spatialdata/OriginalPositionMode.ts
@@ -1,0 +1,19 @@
+export enum OriginalPositionMode {
+  /**
+   * Original positions are hidden.
+   */
+  Hidden,
+
+  /**
+   * Visualize original positions with altitude change.
+   */
+  Altitude,
+
+  /**
+   * Visualize original positions without altitude change,
+   * i.e. as flat lines from the camera origin.
+   */
+  Flat,
+}
+
+export default OriginalPositionMode;

--- a/src/component/spatialdata/SpatialDataComponent.ts
+++ b/src/component/spatialdata/SpatialDataComponent.ts
@@ -61,6 +61,7 @@ import CameraVisualizationMode from "./CameraVisualizationMode";
 import IClusterReconstruction from "../../api/interfaces/IClusterReconstruction";
 import ICellCorners, { ICellNeighbors } from "../../api/interfaces/ICellCorners";
 import Spatial from "../../geo/Spatial";
+import OriginalPositionMode from "./OriginalPositionMode";
 import { FilterFunction } from "../../graph/FilterCreator";
 import SubscriptionHolder from "../../utils/SubscriptionHolder";
 
@@ -310,6 +311,7 @@ export class SpatialDataComponent extends Component<ISpatialDataConfiguration> {
                         cameraVisualizationMode: c.cameraVisualizationMode,
                         camerasVisible: c.camerasVisible,
                         connectedComponents: c.connectedComponents,
+                        originalPositionMode: c.originalPositionMode,
                         pointSize: c.pointSize,
                         pointsVisible: c.pointsVisible,
                         positionsVisible: c.positionsVisible,
@@ -322,6 +324,7 @@ export class SpatialDataComponent extends Component<ISpatialDataConfiguration> {
                         c1.cameraVisualizationMode === c2.cameraVisualizationMode &&
                         c1.camerasVisible === c2.camerasVisible &&
                         c1.connectedComponents === c2.connectedComponents &&
+                        c1.originalPositionMode === c2.originalPositionMode &&
                         c1.pointSize === c2.pointSize &&
                         c1.pointsVisible === c2.pointsVisible &&
                         c1.positionsVisible === c2.positionsVisible &&
@@ -333,12 +336,16 @@ export class SpatialDataComponent extends Component<ISpatialDataConfiguration> {
                     this._scene.setCameraVisibility(c.camerasVisible);
                     this._scene.setPointSize(c.pointSize);
                     this._scene.setPointVisibility(c.pointsVisible);
-                    this._scene.setPositionVisibility(c.positionsVisible);
                     this._scene.setTileVisibility(c.tilesVisible);
-                    const cvm: CameraVisualizationMode = c.connectedComponents ?
+                    const cvm = c.connectedComponents ?
                         CameraVisualizationMode.ConnectedComponent :
                         c.cameraVisualizationMode;
                     this._scene.setCameraVisualizationMode(cvm);
+                    const pm = c.positionsVisible ?
+                        OriginalPositionMode.Flat :
+                        c.originalPositionMode;
+                    this._scene.setPositionMode(pm);
+
                 }));
 
         subs.push(hash$
@@ -491,6 +498,7 @@ export class SpatialDataComponent extends Component<ISpatialDataConfiguration> {
             cameraVisualizationMode: CameraVisualizationMode.Default,
             camerasVisible: false,
             connectedComponents: false,
+            originalPositionMode: OriginalPositionMode.Hidden,
             pointSize: 0.1,
             pointsVisible: true,
             positionsVisible: false,
@@ -547,7 +555,7 @@ export class SpatialDataComponent extends Component<ISpatialDataConfiguration> {
         return this._geoCoords.geodeticToEnu(
             node.originalLatLon.lat,
             node.originalLatLon.lon,
-            node.alt,
+            node.originalAlt != null ? node.originalAlt : node.alt,
             reference.lat,
             reference.lon,
             reference.alt);

--- a/src/component/spatialdata/SpatialDataExport.ts
+++ b/src/component/spatialdata/SpatialDataExport.ts
@@ -1,2 +1,3 @@
 export { CameraVisualizationMode } from "./CameraVisualizationMode";
+export { OriginalPositionMode } from "./OriginalPositionMode";
 export { SpatialDataComponent } from "./SpatialDataComponent";

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -387,6 +387,15 @@ export class Node {
     }
 
     /**
+     * Get originalAlt.
+     *
+     * @returns {number} EXIF altitude, in meters, if available.
+     */
+    public get originalAlt(): number {
+        return this._fill.altitude;
+    }
+
+    /**
      * Get originalCA.
      *
      * @returns {number} Original EXIF compass angle, measured in


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make it possible to display the difference between original EXIF altitude and SfM computed altitude.

## Contribution

Add option for visualizing the original position altitude
instead of flat lines.
Deprecate positionsVisible property.
Add altitude property to fill interface and node class.
