### PR TITLE
fix: handle mouse up not fired outside of window

### DIFF
--- a/spec/helper/EventHelper.ts
+++ b/spec/helper/EventHelper.ts
@@ -3,27 +3,31 @@ export class EventHelper {
         return new KeyboardEvent(typeArg, eventInitDict);
     }
 
-    public static createMouseEvent(eventType: string, params: MouseEventInit, target?: EventTarget): MouseEvent {
-        const mouseEvent: MouseEvent = document.createEvent("MouseEvent");
-
-        mouseEvent.initMouseEvent(
+    public static createMouseEvent(
+        eventType: string,
+        params: MouseEventInit,
+        target?: EventTarget): MouseEvent {
+        return new MouseEvent(
             eventType,
-            params.bubbles !== undefined ? params.bubbles : true,
-            params.cancelable !== undefined ? params.cancelable : true,
-            window,
-            params.detail !== undefined ? params.detail : 0,
-            params.screenX !== undefined ? params.screenX : 0,
-            params.screenY !== undefined ? params.screenY : 0,
-            params.clientX !== undefined ? params.clientX : 0,
-            params.clientY !== undefined ? params.clientY : 0,
-            !!params.ctrlKey,
-            !!params.altKey,
-            !!params.shiftKey,
-            !!params.metaKey,
-            params.button !== undefined ? params.button : 0,
-            !!target ? target : document.createElement("div"));
-
-        return mouseEvent;
+            {
+                bubbles: params.bubbles !== undefined ?
+                    params.bubbles : true,
+                cancelable: params.cancelable !== undefined ?
+                    params.cancelable : true,
+                detail: params.detail !== undefined ? params.detail : 0,
+                screenX: params.screenX !== undefined ? params.screenX : 0,
+                screenY: params.screenY !== undefined ? params.screenY : 0,
+                clientX: params.clientX !== undefined ? params.clientX : 0,
+                clientY: params.clientY !== undefined ? params.clientY : 0,
+                ctrlKey: !!params.ctrlKey,
+                altKey: !!params.altKey,
+                shiftKey: !!params.shiftKey,
+                metaKey: !!params.metaKey,
+                button: params.button !== undefined ? params.button : 0,
+                buttons: params.buttons !== undefined ? params.button : 1,
+                relatedTarget: !!target ?
+                    target : document.createElement("div"),
+            });
     }
 
     public static createTouchEvent(eventType: string, shiftKey?: boolean): TouchEvent {


### PR DESCRIPTION
## Motivation

Handle released right mouse drag outside of window to avoid drag rotating without buttons pressed.

## Contribution

(If this PR adds or changes functionality, describe it here.)

## Test Plan

```
yarn build
yarn test
yarn start
```
1. Start right mouse drag in in spatial view
2. Release right mouse outside of the browser window
3. Move the mouse cursor inside the window again
4. No interaction occurs until mouse press again
