### PR TITLE
Make sequence api singular

### DIFF
--- a/spec/api/APIWrapper.spec.ts
+++ b/spec/api/APIWrapper.spec.ts
@@ -200,21 +200,20 @@ describe("APIWrappersequenceByKey$", () => {
         };
 
         const provider = new DataProvider();
-        const providerSpy: jasmine.Spy = spyOn(provider, "getSequences");
+        const providerSpy: jasmine.Spy = spyOn(provider, "getSequence");
         providerSpy.and.returnValue(promise);
 
         const api: APIWrapper = new APIWrapper(provider);
 
         const skey: string = "skey";
 
-        api.getSequences$([skey])
+        api.getSequence$(skey)
             .subscribe(
                 (result): void => {
                     expect(result).toBeDefined();
 
                     expect(providerSpy.calls.count()).toBe(1);
-                    expect(providerSpy.calls.first().args[0].length).toBe(1);
-                    expect(providerSpy.calls.first().args[0][0]).toBe(skey);
+                    expect(providerSpy.calls.first().args[0]).toBe(skey);
 
                     done();
                 });
@@ -228,14 +227,14 @@ describe("APIWrappersequenceByKey$", () => {
         };
 
         const provider = new DataProvider();
-        const providerSpy: jasmine.Spy = spyOn(provider, "getSequences");
+        const providerSpy: jasmine.Spy = spyOn(provider, "getSequence");
         providerSpy.and.returnValue(promise);
 
         const api: APIWrapper = new APIWrapper(provider);
 
         const skey: string = "skey";
 
-        api.getSequences$([skey]).pipe(
+        api.getSequence$(skey).pipe(
             catchError(
                 (err: Error): Observable<{}> => {
                     expect(err).toBeDefined();

--- a/spec/api/falcor/FalcorDataProvider.spec.ts
+++ b/spec/api/falcor/FalcorDataProvider.spec.ts
@@ -422,7 +422,7 @@ describe("FalcorDataProvider.getSequences", () => {
 
         const skey = "skey";
 
-        provider.getSequences([skey])
+        provider.getSequence(skey)
             .then(
                 (result): void => {
                     expect(result).toBeDefined();
@@ -462,7 +462,7 @@ describe("FalcorDataProvider.getSequences", () => {
 
         const skey = "skey";
 
-        provider.getSequences([skey])
+        provider.getSequence(skey)
             .then(
                 (): void => { return; },
                 (): void => {
@@ -503,14 +503,13 @@ describe("FalcorDataProvider.getSequences", () => {
             creator: creator,
         });
 
-        provider.getSequences([skey])
+        provider.getSequence(skey)
             .then(
                 (result): void => {
                     expect(result).toBeDefined();
-                    expect(result[0]).toBeDefined();
-                    expect(result[0].node_id).toBe(skey);
-                    expect(result[0].node.image_ids.length).toBe(1);
-                    expect(result[0].node.image_ids[0]).toBe(nkey);
+                    expect(result.id).toBe(skey);
+                    expect(result.image_ids.length).toBe(1);
+                    expect(result.image_ids[0]).toBe(nkey);
 
                     done();
                 });
@@ -541,14 +540,12 @@ describe("FalcorDataProvider.getSequences", () => {
 
         const skey = "skey";
 
-        provider.getSequences([skey])
+        provider.getSequence(skey)
             .then(
                 (result): void => {
                     expect(result).toBeDefined();
-                    expect(result[0]).toBeDefined();
-                    expect(result[0].node_id).toBe(skey);
-                    expect(result[0].node.id).toBe(skey);
-                    expect(result[0].node.image_ids.length).toBe(0);
+                    expect(result.id).toBe(skey);
+                    expect(result.image_ids.length).toBe(0);
 
                     done();
                 });
@@ -579,14 +576,13 @@ describe("FalcorDataProvider.getSequences", () => {
 
         const skey = "skey";
 
-        provider.getSequences([skey])
+        provider.getSequence(skey)
             .then(
                 (result): void => {
                     expect(result).toBeDefined();
-                    expect(result[0]).toBeDefined();
-                    expect(result[0].node_id).toBe(skey);
-                    expect(result[0].node.id).toBe(skey);
-                    expect(result[0].node.image_ids.length).toBe(0);
+                    expect(result).toBeDefined();
+                    expect(result.id).toBe(skey);
+                    expect(result.image_ids.length).toBe(0);
 
                     done();
                 });

--- a/spec/graph/Graph.spec.ts
+++ b/spec/graph/Graph.spec.ts
@@ -18,21 +18,17 @@ import { APIWrapper } from "../../src/api/APIWrapper";
 import { FalcorDataProvider } from "../../src/api/falcor/FalcorDataProvider";
 import { GeohashGeometryProvider } from "../../src/api/GeohashGeometryProvider";
 import { CoreImageEnt } from "../../src/api/ents/CoreImageEnt";
-import { SpatialImageEnt } from "../../src/api/ents/SpatialImageEnt";
 import { ImageEnt } from "../../src/api/ents/ImageEnt";
 import { GraphMapillaryError } from "../../src/error/GraphMapillaryError";
 import { EdgeCalculator } from "../../src/graph/edge/EdgeCalculator";
-import {
-    Graph,
-    NodeIndexItem,
-} from "../../src/graph/Graph";
+import { Graph } from "../../src/graph/Graph";
 import { GraphCalculator } from "../../src/graph/GraphCalculator";
-import { GraphConfiguration } from "../../src/graph/interfaces/GraphConfiguration";
-import { Sequence } from "../../src/graph/Sequence";
-import { DataProvider, GeometryProvider } from "../helper/ProviderHelper";
-import { SequenceEnt } from "../../src/api/ents/SequenceEnt";
-import { SpatialImagesContract } from "../../src/api/contracts/SpatialImagesContract";
-import { SequencesContract } from "../../src/api/contracts/SequencesContract";
+import { GraphConfiguration }
+    from "../../src/graph/interfaces/GraphConfiguration";
+import { DataProvider } from "../helper/ProviderHelper";
+import { SpatialImagesContract }
+    from "../../src/api/contracts/SpatialImagesContract";
+import { SequenceContract } from "../../src/api/contracts/SequenceContract";
 import { ImagesContract } from "../../src/api/contracts/ImagesContract";
 import { CoreImagesContract } from "../../src/api/contracts/CoreImagesContract";
 
@@ -889,8 +885,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -902,12 +898,9 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [id] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = { id: sequenceId, image_ids: [id] };
+        getSequence.next(result);
+        getSequence.complete();
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(false);
     });
@@ -917,8 +910,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -930,12 +923,9 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [id] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = { id: sequenceId, image_ids: [id] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -947,8 +937,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -960,12 +950,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1001,8 +989,8 @@ describe("Graph.cacheSequenceNodes$", () => {
             maxUnusedTiles: 0,
         };
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1014,12 +1002,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1057,8 +1043,8 @@ describe("Graph.cacheSequenceNodes$", () => {
             maxUnusedTiles: 1,
         };
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1070,12 +1056,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1115,8 +1099,8 @@ describe("Graph.cacheSequenceNodes$", () => {
             maxUnusedTiles: 0,
         };
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1128,12 +1112,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1171,8 +1153,8 @@ describe("Graph.cacheSequenceNodes$", () => {
             maxUnusedTiles: 0,
         };
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1184,12 +1166,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1229,8 +1209,8 @@ describe("Graph.cacheSequenceNodes$", () => {
             maxUnusedTiles: 0,
         };
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1242,12 +1222,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1313,8 +1291,8 @@ describe("Graph.cacheSequenceNodes$", () => {
             maxUnusedTiles: 0,
         };
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1326,12 +1304,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1383,8 +1359,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1396,12 +1372,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1422,8 +1396,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1436,12 +1410,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
         graph.cacheSequenceNodes$(sequenceId).subscribe();
@@ -1463,8 +1435,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(imageByKey);
@@ -1476,12 +1448,10 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [nodeKey] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [nodeKey] };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId)
             .subscribe(
@@ -1500,8 +1470,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1513,17 +1483,14 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: {
-                id: sequenceId,
-                image_ids: Array(200)
-                    .fill(undefined)
-                    .map((_, i) => i.toString())
-            },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: sequenceId,
+            image_ids: Array(200)
+                .fill(undefined)
+                .map((_, i) => i.toString())
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1543,8 +1510,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1556,17 +1523,14 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         graph.cacheSequence$(sequenceId).subscribe();
 
-        const result: SequencesContract = [{
-            node: {
-                id: sequenceId,
-                image_ids: Array(201)
-                    .fill(undefined)
-                    .map((_, i) => i.toString()),
-            },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: sequenceId,
+            image_ids: Array(201)
+                .fill(undefined)
+                .map((_, i) => i.toString()),
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId).subscribe();
 
@@ -1587,8 +1551,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1602,19 +1566,16 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         const referenceNodeKey = "referenceNodeKey";
 
-        const result: SequencesContract = [{
-            node: {
-                id: sequenceId,
-                image_ids: Array
-                    .from(
-                        new Array(400),
-                        (_, i): string => i.toString())
-            },
-            node_id: sequenceId,
-        }];
-        result[0].node.image_ids.splice(0, 1, referenceNodeKey);
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: sequenceId,
+            image_ids: Array
+                .from(
+                    new Array(400),
+                    (_, i): string => i.toString())
+        };
+        result.image_ids.splice(0, 1, referenceNodeKey);
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId, referenceNodeKey).subscribe();
 
@@ -1637,8 +1598,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1652,19 +1613,16 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         const referenceNodeKey = "referenceNodeKey";
 
-        const result: SequencesContract = [{
-            node: {
-                id: sequenceId,
-                image_ids: Array
-                    .from(
-                        new Array(400),
-                        (_, i) => i.toString()),
-            },
-            node_id: sequenceId,
-        }];
-        result[0].node.image_ids.splice(399, 1, referenceNodeKey);
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: sequenceId,
+            image_ids: Array
+                .from(
+                    new Array(400),
+                    (_, i) => i.toString()),
+        };
+        result.image_ids.splice(399, 1, referenceNodeKey);
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId, referenceNodeKey).subscribe();
 
@@ -1688,8 +1646,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1703,19 +1661,16 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         const referenceNodeKey = "referenceNodeKey";
 
-        const result: SequencesContract = [{
-            node: {
-                id: sequenceId,
-                image_ids: Array
-                    .from(
-                        new Array(400),
-                        (_, i) => i.toString()),
-            },
-            node_id: sequenceId,
-        }];
-        result[0].node.image_ids.splice(200, 1, referenceNodeKey);
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: sequenceId,
+            image_ids: Array
+                .from(
+                    new Array(400),
+                    (_, i) => i.toString()),
+        };
+        result.image_ids.splice(200, 1, referenceNodeKey);
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId, referenceNodeKey).subscribe();
 
@@ -1740,8 +1695,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1755,26 +1710,23 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         const referenceNodeKey = "referenceNodeKey";
 
-        const result: SequencesContract = [{
-            node: {
-                id: sequenceId,
-                image_ids: Array
-                    .from(
-                        new Array(400),
-                        (_, i) => i.toString()),
-            },
-            node_id: sequenceId,
-        }];
-        result[0].node.image_ids.splice(200, 1, referenceNodeKey);
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: sequenceId,
+            image_ids: Array
+                .from(
+                    new Array(400),
+                    (_, i) => i.toString()),
+        };
+        result.image_ids.splice(200, 1, referenceNodeKey);
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId, referenceNodeKey).subscribe();
 
         expect(graph.isCachingSequenceNodes(sequenceId)).toBe(true);
         expect(graph.getSequence(sequenceId).imageIds.length).toBe(400);
         expect(graph.getSequence(sequenceId).imageIds)
-            .toEqual(result[0].node.image_ids);
+            .toEqual(result.image_ids);
     });
 
     it("should create single batch when fewer than or equal to 50 nodes", () => {
@@ -1782,8 +1734,8 @@ describe("Graph.cacheSequenceNodes$", () => {
         const graphCalculator = new GraphCalculator(null);
         const edgeCalculator = new EdgeCalculator();
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const imageByKey = new Subject<ImagesContract>();
         const imageByKeySpy = spyOn(api, "getImages$");
@@ -1797,19 +1749,16 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         const referenceNodeKey = "referenceNodeKey";
 
-        const result: SequencesContract = [{
-            node: {
-                id: sequenceId,
-                image_ids: Array
-                    .from(
-                        new Array(50),
-                        (_, i) => i.toString()),
-            },
-            node_id: sequenceId,
-        }];
-        result[0].node.image_ids.splice(20, 1, referenceNodeKey);
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: sequenceId,
+            image_ids: Array
+                .from(
+                    new Array(50),
+                    (_, i) => i.toString()),
+        };
+        result.image_ids.splice(20, 1, referenceNodeKey);
+        getSequence.next(result);
+        getSequence.complete();
 
         graph.cacheSequenceNodes$(sequenceId, referenceNodeKey).subscribe();
 
@@ -1938,8 +1887,8 @@ describe("Graph.cacheSpatialEdges", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, graphCalculator, edgeCalculator);
         graph.cacheFull$(fullNode.id).subscribe(() => { /*noop*/ });
@@ -1953,15 +1902,12 @@ describe("Graph.cacheSpatialEdges", () => {
 
         graph.cacheNodeSequence$(fullNode.id).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: ["prev", fullNode.id, "next"],
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: ["prev", fullNode.id, "next"],
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         const node = graph.getNode(fullNode.id);
 
@@ -2014,8 +1960,8 @@ describe("Graph.cacheSpatialEdges", () => {
             new Subject<CoreImagesContract>();
         spyOn(api, "getCoreImages$").and.returnValue(coreImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(
             api,
@@ -2034,15 +1980,12 @@ describe("Graph.cacheSpatialEdges", () => {
 
         graph.cacheNodeSequence$(fullNode.id).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: ["prev", fullNode.id, "next"],
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: ["prev", fullNode.id, "next"],
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         const node = graph.getNode(fullNode.id);
         expect(node).toBeDefined();
@@ -2105,8 +2048,8 @@ describe("Graph.cacheSpatialEdges", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, graphCalculator, edgeCalculator);
         graph.cacheFull$(fullNode.id).subscribe(() => { /*noop*/ });
@@ -2120,15 +2063,12 @@ describe("Graph.cacheSpatialEdges", () => {
 
         graph.cacheNodeSequence$(fullNode.id).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: ["prev", fullNode.id, "next"],
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: ["prev", fullNode.id, "next"],
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         const node = graph.getNode(fullNode.id);
 
@@ -2196,8 +2136,8 @@ describe("Graph.cacheNodeSequence$", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2225,8 +2165,8 @@ describe("Graph.cacheNodeSequence$", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2248,15 +2188,12 @@ describe("Graph.cacheNodeSequence$", () => {
                     expect(g.isCachingNodeSequence(fullNode.id)).toBe(false);
                 });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: [fullNode.id],
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: [fullNode.id],
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         expect(graph.hasNodeSequence(fullNode.id)).toBe(true);
         expect(graph.isCachingNodeSequence(fullNode.id)).toBe(false);
@@ -2269,8 +2206,8 @@ describe("Graph.cacheNodeSequence$", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2287,8 +2224,8 @@ describe("Graph.cacheNodeSequence$", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2305,15 +2242,12 @@ describe("Graph.cacheNodeSequence$", () => {
 
         graph.cacheNodeSequence$(fullNode.id).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: [fullNode.id],
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: [fullNode.id],
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         expect(graph.hasNodeSequence(fullNode.id)).toBe(true);
 
@@ -2327,9 +2261,9 @@ describe("Graph.cacheNodeSequence$", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        const sequenceByKeySpy = spyOn(api, "getSequences$");
-        sequenceByKeySpy.and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        const sequenceByKeySpy = spyOn(api, "getSequence$");
+        sequenceByKeySpy.and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2357,8 +2291,8 @@ describe("Graph.cacheNodeSequence$", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2385,15 +2319,12 @@ describe("Graph.cacheNodeSequence$", () => {
                     done();
                 });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: [fullNode.id],
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: [fullNode.id],
+        };
+        getSequence.next(result);
+        getSequence.complete();
     });
 });
 
@@ -2424,8 +2355,8 @@ describe("Graph.cacheSequence$", () => {
         const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
         const calculator = new GraphCalculator(null);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2441,8 +2372,8 @@ describe("Graph.cacheSequence$", () => {
         const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
         const calculator = new GraphCalculator(null);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2462,21 +2393,19 @@ describe("Graph.cacheSequence$", () => {
                     done();
                 });
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [id] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [id] };
+        getSequence.next(result);
+        getSequence.complete();
     });
 
     it("should call api only once when caching the same sequence twice in succession", () => {
         const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
         const calculator = new GraphCalculator(null);
 
-        const getSequences = new Subject<SequencesContract>();
-        const sequenceByKeySpy = spyOn(api, "getSequences$");
-        sequenceByKeySpy.and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        const sequenceByKeySpy = spyOn(api, "getSequence$");
+        sequenceByKeySpy.and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, calculator);
 
@@ -2506,8 +2435,8 @@ describe("Graph.resetSpatialEdges", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, graphCalculator, edgeCalculator);
         graph.cacheFull$(fullNode.id).subscribe(() => { /*noop*/ });
@@ -2521,15 +2450,12 @@ describe("Graph.resetSpatialEdges", () => {
 
         graph.cacheNodeSequence$(fullNode.id).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: ["prev", fullNode.id, "next"]
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: ["prev", fullNode.id, "next"]
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         const node = graph.getNode(fullNode.id);
 
@@ -2579,8 +2505,8 @@ describe("Graph.resetSpatialEdges", () => {
         const getImages = new Subject<ImagesContract>();
         spyOn(api, "getImages$").and.returnValue(getImages);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const graph = new Graph(api, undefined, graphCalculator, edgeCalculator);
         graph.cacheFull$(fullNode.id).subscribe(() => { /*noop*/ });
@@ -2594,15 +2520,12 @@ describe("Graph.resetSpatialEdges", () => {
 
         graph.cacheNodeSequence$(fullNode.id).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: {
-                id: fullNode.sequence.id,
-                image_ids: ["prev", fullNode.id, "next"]
-            },
-            node_id: fullNode.sequence.id,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract = {
+            id: fullNode.sequence.id,
+            image_ids: ["prev", fullNode.id, "next"]
+        };
+        getSequence.next(result);
+        getSequence.complete();
 
         expect(graph.hasTiles(fullNode.id)).toBe(false);
         expect(graph.isCachingTiles(fullNode.id)).toBe(false);
@@ -3492,8 +3415,8 @@ describe("Graph.uncache", () => {
         const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
         const calculator = new GraphCalculator(null);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const configuration: GraphConfiguration = {
             maxSequences: 0,
@@ -3508,12 +3431,10 @@ describe("Graph.uncache", () => {
 
         graph.cacheSequence$(sequenceId).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [] };
+        getSequence.next(result);
+        getSequence.complete();
 
         expect(graph.hasSequence(sequenceId)).toBe(true);
 
@@ -3533,8 +3454,8 @@ describe("Graph.uncache", () => {
         const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
         const calculator = new GraphCalculator(null);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const configuration: GraphConfiguration = {
             maxSequences: 0,
@@ -3549,12 +3470,10 @@ describe("Graph.uncache", () => {
 
         graph.cacheSequence$(sequenceId).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [] };
+        getSequence.next(result);
+        getSequence.complete();
 
         expect(graph.hasSequence(sequenceId)).toBe(true);
 
@@ -3575,8 +3494,8 @@ describe("Graph.uncache", () => {
             new FalcorDataProvider({ clientToken: "cid" }));
         const calculator = new GraphCalculator(null);
 
-        const getSequences = new Subject<SequencesContract>();
-        spyOn(api, "getSequences$").and.returnValue(getSequences);
+        const getSequence = new Subject<SequenceContract>();
+        spyOn(api, "getSequence$").and.returnValue(getSequence);
 
         const configuration: GraphConfiguration = {
             maxSequences: 1,
@@ -3591,12 +3510,10 @@ describe("Graph.uncache", () => {
 
         graph.cacheSequence$(sequenceId).subscribe(() => { /*noop*/ });
 
-        const result: SequencesContract = [{
-            node: { id: sequenceId, image_ids: [] },
-            node_id: sequenceId,
-        }];
-        getSequences.next(result);
-        getSequences.complete();
+        const result: SequenceContract =
+            { id: sequenceId, image_ids: [] };
+        getSequence.next(result);
+        getSequence.complete();
 
         expect(graph.hasSequence(sequenceId)).toBe(true);
 
@@ -3616,7 +3533,7 @@ describe("Graph.uncache", () => {
         const api = new APIWrapper(
             new FalcorDataProvider({ clientToken: "cid" }));
         const calculator = new GraphCalculator(null);
-        const getSequencesSpy = spyOn(api, "getSequences$");
+        const getSequenceSpy = spyOn(api, "getSequence$");
         const configuration: GraphConfiguration = {
             maxSequences: 1,
             maxUnusedNodes: 0,
@@ -3632,15 +3549,13 @@ describe("Graph.uncache", () => {
             configuration);
 
         const sequenceId1 = "sequenceId1";
-        const sequences1 = new Subject<SequencesContract>();
-        getSequencesSpy.and.returnValue(sequences1);
+        const sequences1 = new Subject<SequenceContract>();
+        getSequenceSpy.and.returnValue(sequences1);
 
         graph.cacheSequence$(sequenceId1).subscribe(() => { /*noop*/ });
 
-        const result1: SequencesContract = [{
-            node_id: sequenceId1,
-            node: { id: sequenceId1, image_ids: [] },
-        }];
+        const result1: SequenceContract =
+            { id: sequenceId1, image_ids: [] };
         sequences1.next(result1);
         sequences1.complete();
 
@@ -3650,17 +3565,15 @@ describe("Graph.uncache", () => {
         const sequenceDisposeSpy1 = spyOn(sequence1, "dispose").and.stub();
 
         const sequenceId2 = "sequenceId2";
-        const getSequences2 = new Subject<SequencesContract>();
-        getSequencesSpy.and.returnValue(getSequences2);
+        const getSequence2 = new Subject<SequenceContract>();
+        getSequenceSpy.and.returnValue(getSequence2);
 
         graph.cacheSequence$(sequenceId2).subscribe(() => { /*noop*/ });
 
-        const result2: SequencesContract = [{
-            node_id: sequenceId2,
-            node: { id: sequenceId2, image_ids: [] },
-        }];
-        getSequences2.next(result2);
-        getSequences2.complete();
+        const result2: SequenceContract =
+            { id: sequenceId2, image_ids: [] };
+        getSequence2.next(result2);
+        getSequence2.complete();
 
         expect(graph.hasSequence(sequenceId2)).toBe(true);
         const sequence2 = graph.getSequence(sequenceId2);

--- a/src/api/APIWrapper.ts
+++ b/src/api/APIWrapper.ts
@@ -6,7 +6,7 @@ import { DataProviderBase } from "./DataProviderBase";
 import { CoreImagesContract } from "./contracts/CoreImagesContract";
 import { ImagesContract } from "./contracts/ImagesContract";
 import { SpatialImagesContract } from "./contracts/SpatialImagesContract";
-import { SequencesContract } from "./contracts/SequencesContract";
+import { SequenceContract } from "./contracts/SequenceContract";
 import { ImageTilesRequestContract }
     from "./contracts/ImageTilesRequestContract";
 import { ImageTilesContract } from "./contracts/ImageTilesContract";
@@ -35,11 +35,10 @@ export class APIWrapper {
         tiles: ImageTilesRequestContract)
         : Observable<ImageTilesContract> {
         return this._wrap$(this._data.getImageTiles(tiles));
-
     }
 
-    public getSequences$(sequenceIds: string[]): Observable<SequencesContract> {
-        return this._wrap$(this._data.getSequences(sequenceIds));
+    public getSequence$(sequenceId: string): Observable<SequenceContract> {
+        return this._wrap$(this._data.getSequence(sequenceId));
     }
 
     public getSpatialImages$(

--- a/src/api/DataProviderBase.ts
+++ b/src/api/DataProviderBase.ts
@@ -7,9 +7,10 @@ import { GeometryProviderBase } from "./GeometryProviderBase";
 import { CoreImagesContract } from "./contracts/CoreImagesContract";
 import { SpatialImagesContract } from "./contracts/SpatialImagesContract";
 import { ImagesContract } from "./contracts/ImagesContract";
-import { SequencesContract } from "./contracts/SequencesContract";
+import { SequenceContract } from "./contracts/SequenceContract";
 import { ImageTilesContract } from "./contracts/ImageTilesContract";
-import { ImageTilesRequestContract } from "./contracts/ImageTilesRequestContract";
+import { ImageTilesRequestContract }
+    from "./contracts/ImageTilesRequestContract";
 
 /**
  * @class DataProviderBase
@@ -166,16 +167,16 @@ export abstract class DataProviderBase extends EventEmitter {
     }
 
     /**
-     * Get sequences.
+     * Get sequence.
      *
-     * @param {Array<string>} sequenceIds - The ids for the
-     * sequences to retrieve.
+     * @param {Array<string>} sequenceId - The id for the
+     * sequence to retrieve.
      * @returns {Promise} Promise to the sequences of the
      * requested image ids.
      * @throws {Error} Rejects the promise on errors.
      */
-    public getSequences(
-        sequenceIds: string[]): Promise<SequencesContract> {
+    public getSequence(
+        sequenceId: string): Promise<SequenceContract> {
         return Promise.reject(new MapillaryError("Not implemented"));
     }
 

--- a/src/api/contracts/SequenceContract.ts
+++ b/src/api/contracts/SequenceContract.ts
@@ -1,0 +1,3 @@
+import { SequenceEnt } from "../ents/SequenceEnt";
+
+export type SequenceContract = SequenceEnt;

--- a/src/api/contracts/SequencesContract.ts
+++ b/src/api/contracts/SequencesContract.ts
@@ -1,4 +1,0 @@
-import { SequenceEnt } from "../ents/SequenceEnt";
-import { EntContract } from "./EntContract";
-
-export type SequencesContract = EntContract<SequenceEnt>[];

--- a/src/api/falcor/FalcorDataProvider.ts
+++ b/src/api/falcor/FalcorDataProvider.ts
@@ -11,7 +11,7 @@ import { ClusterReconstructionContract }
 import { MeshContract } from "../contracts/MeshContract";
 import { CoreImagesContract } from "../contracts/CoreImagesContract";
 import { SpatialImagesContract } from "../contracts/SpatialImagesContract";
-import { SequencesContract } from "../contracts/SequencesContract";
+import { SequenceContract } from "../contracts/SequenceContract";
 import { ImagesContract } from "../contracts/ImagesContract";
 import { CoreImageEnt } from "../ents/CoreImageEnt";
 import {
@@ -256,35 +256,31 @@ export class FalcorDataProvider extends DataProviderBase {
     }
 
     /** @inheritdoc */
-    public getSequences(sequenceIds: string[]): Promise<SequencesContract> {
+    public getSequence(sequenceId: string): Promise<SequenceContract> {
         return Promise
             .resolve(<PromiseLike<FalcorSequenceByKeyContract>>this._model
                 .get([
                     this._pathSequenceByKey,
-                    sequenceIds,
+                    [sequenceId],
                     this._convert.propertiesKey
                         .concat(this._convert.propertiesSequence)]))
             .then(
-                (value: FalcorSequenceByKeyContract): SequencesContract => {
+                (value: FalcorSequenceByKeyContract): SequenceContract => {
                     if (!value) { value = { json: { sequenceByKey: {} } }; }
-                    const result: SequencesContract = [];
-                    for (const sequenceId of sequenceIds) {
-                        const exists = sequenceId in value.json.sequenceByKey;
-                        if (!exists) {
-                            console
-                                .warn(`Sequence data missing (${sequenceId})`);
-                        }
-                        const sequence = exists ?
-                            this._convert.sequence(
-                                value.json.sequenceByKey[sequenceId]) :
-                            this._convert.sequence(
-                                { key: sequenceId, keys: [] });
-                        result.push({ node: sequence, node_id: sequenceId });
+                    const exists = sequenceId in value.json.sequenceByKey;
+                    if (!exists) {
+                        console
+                            .warn(`Sequence data missing (${sequenceId})`);
                     }
-                    return result;
+                    const sequence = exists ?
+                        this._convert.sequence(
+                            value.json.sequenceByKey[sequenceId]) :
+                        this._convert.sequence(
+                            { key: sequenceId, keys: [] });
+                    return sequence;
                 },
                 (error: Error) => {
-                    this._invalidateGet(this._pathSequenceByKey, sequenceIds);
+                    this._invalidateGet(this._pathSequenceByKey, [sequenceId]);
                     throw error;
                 });
     }

--- a/src/export/APINamespace.ts
+++ b/src/export/APINamespace.ts
@@ -26,7 +26,7 @@ export { MeshContract } from "../api/contracts/MeshContract";
 export { PointContract } from "../api/contracts/PointContract";
 export { ImageTilesRequestContract }
     from "../api/contracts/ImageTilesRequestContract";
-export { SequencesContract } from "../api/contracts/SequencesContract";
+export { SequenceContract } from "../api/contracts/SequenceContract";
 export { SpatialImagesContract } from "../api/contracts/SpatialImagesContract";
 
 // Ent

--- a/src/graph/Graph.ts
+++ b/src/graph/Graph.ts
@@ -40,7 +40,7 @@ import { LatLon } from "../api/interfaces/LatLon";
 import { GraphMapillaryError } from "../error/GraphMapillaryError";
 import { SpatialImagesContract } from "../api/contracts/SpatialImagesContract";
 import { ImagesContract } from "../api/contracts/ImagesContract";
-import { SequencesContract } from "../api/contracts/SequencesContract";
+import { SequenceContract } from "../api/contracts/SequenceContract";
 import { CoreImagesContract } from "../api/contracts/CoreImagesContract";
 
 type NodeTiles = {
@@ -1619,22 +1619,20 @@ export class Graph {
         }
 
         this._cachingSequences$[sequenceId] = this._api
-            .getSequences$([sequenceId])
+            .getSequence$(sequenceId)
             .pipe(
                 tap(
-                    (sequences: SequencesContract): void => {
-                        for (const sequence of sequences) {
-                            if (!sequence.node) {
-                                console.warn(
-                                    `Sequence does not exist ` +
-                                    `(${sequence.node_id})`);
-                            } else {
-                                if (!(sequence.node_id in this._sequences)) {
-                                    this._sequences[sequence.node_id] = {
-                                        accessed: new Date().getTime(),
-                                        sequence: new Sequence(sequence.node),
-                                    };
-                                }
+                    (sequence: SequenceContract): void => {
+                        if (!sequence) {
+                            console.warn(
+                                `Sequence does not exist ` +
+                                `(${sequenceId})`);
+                        } else {
+                            if (!(sequence.id in this._sequences)) {
+                                this._sequences[sequence.id] = {
+                                    accessed: new Date().getTime(),
+                                    sequence: new Sequence(sequence),
+                                };
                             }
 
                             delete this._cachingSequences$[sequenceId];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Simplify data provider sequence API because sequences are always requested one at a time

## Contribution

- Replace `DataProviderBase.getSequences` with `DataProviderBase.getSequence`

## Test Plan

```
yarn prepare
yarn test
yarn start
```
`http://localhost:8000`
