### PR TITLE
Add default active track resize option

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -43,9 +43,9 @@
     <button onclick="setFilter()">Filter</button>
     <button onclick="remove()">Remove</button>
     <script>
-        const sup = Mapillary.isSupported();
-        const fSup = Mapillary.isFallbackSupported();
-        console.log(`isSupported: ${sup}, isFallbackSupported: ${fSup}`);
+        const sup = `isSupported: ${Mapillary.isSupported()}`;
+        const fSup = `isFallbackSupported: ${Mapillary.isFallbackSupported()}`;
+        console.log(`${sup}, ${fSup}`);
 
         const viewer = new Mapillary.Viewer({
             apiClient: "QjI1NnU0aG5FZFZISE56U3R5aWN4ZzpkYzg0NzE3MDA0YTRhZjlh",
@@ -54,8 +54,6 @@
             imageId: "zarcRdNFZwg3FkXNcsFeGw",
             renderMode: Mapillary.RenderMode.Letterbox,
         });
-
-        window.addEventListener("resize", function () { viewer.resize(); });
 
         function letterbox() {
             viewer.setRenderMode(Mapillary.RenderMode.Letterbox);

--- a/debug/leaflet.html
+++ b/debug/leaflet.html
@@ -343,10 +343,6 @@
 
             mapMarker.setLatLng([e.marker.latLon.lat, e.marker.latLon.lon]);
         });
-
-
-        // Trigger render on browser window resize
-        window.addEventListener("resize", () => { mly.resize(); });
     </script>
 </body>
 

--- a/debug/markers.html
+++ b/debug/markers.html
@@ -118,8 +118,6 @@
                         5);
                 },
                 function (e) { console.error(e); });
-
-        window.addEventListener("resize", function () { mly.resize(); });
     </script>
 </body>
 

--- a/debug/module.html
+++ b/debug/module.html
@@ -42,8 +42,6 @@
             container: container,
             imageId: "zarcRdNFZwg3FkXNcsFeGw",
         });
-
-        window.addEventListener("resize", function () { viewer.resize(); });
     </script>
 </body>
 

--- a/debug/popup.html
+++ b/debug/popup.html
@@ -96,7 +96,6 @@
                 container,
             };
             const viewer = new Viewer(viewerOptions);
-            window.addEventListener("resize", () => { viewer.resize(); });
             viewer.moveTo("FnqSkFAZXjv4Uqmqd4X_NA")
                 .catch(error => console.error(error));
             return viewer;

--- a/debug/provider.html
+++ b/debug/provider.html
@@ -45,8 +45,6 @@
       container: "mly",
       imageId: "zarcRdNFZwg3FkXNcsFeGw",
     });
-
-    window.addEventListener("resize", function () { viewer.resize(); });
   </script>
 </body>
 

--- a/debug/spatial.html
+++ b/debug/spatial.html
@@ -36,8 +36,6 @@
             imageId: "zarcRdNFZwg3FkXNcsFeGw",
         });
 
-        window.addEventListener("resize", function () { viewer.resize(); });
-
         const spatial = viewer.getComponent("spatialData");
         const s = Object.assign(
             {},

--- a/debug/tags.html
+++ b/debug/tags.html
@@ -48,8 +48,6 @@
             renderMode: Mapillary.RenderMode.Letterbox,
         });
 
-        window.addEventListener("resize", function () { viewer.resize(); });
-
         function deactivate() { viewer.deactivateComponent("tag"); }
 
         function activate() { viewer.activateComponent("tag"); }

--- a/spec/render/RenderService.spec.ts
+++ b/spec/render/RenderService.spec.ts
@@ -124,7 +124,7 @@ describe("RenderService.size", () => {
                 (e: Error): void => { return; },
                 (): void => { done(); });
 
-        renderService.resize$.next(null);
+        renderService.resize$.next();
     });
 });
 
@@ -263,7 +263,7 @@ describe("RenderService.renderCameraFrame", () => {
 
         frame$.next(createFrame(0));
 
-        renderService.resize$.next(null);
+        renderService.resize$.next();
         frame$.next(createFrame(1));
         frame$.complete();
     });
@@ -334,7 +334,7 @@ describe("RenderService.renderCameraFrame", () => {
         frame$.next(createFrame(1));
 
         renderService.renderMode$.next(RenderMode.Fill);
-        renderService.resize$.next(null);
+        renderService.resize$.next();
 
         frame$.next(createFrame(2));
         frame$.next(createFrame(3));
@@ -415,7 +415,7 @@ describe("RenderService.renderCamera$", () => {
         spyOn(element, "getOffsetHeight");
         spyOn(element, "getOffsetWidth");
 
-        renderService.resize$.next(null);
+        renderService.resize$.next();
 
         expect((<jasmine.Spy>element.getOffsetHeight).calls.count()).toBe(1);
         expect((<jasmine.Spy>element.getOffsetWidth).calls.count()).toBe(1);

--- a/src/viewer/Container.ts
+++ b/src/viewer/Container.ts
@@ -31,6 +31,8 @@ export class Container {
 
     private _dom: DOM;
 
+    private readonly _trackResize: boolean;
+
     constructor(
         options: ViewerOptions,
         stateService: StateService,
@@ -52,6 +54,10 @@ export class Container {
                 `Invalid type: "container" must be ` +
                 `a String or HTMLElement.`);
         }
+
+        this._trackResize =
+            options.trackResize === false ?
+                false : true;
 
         this.id = this._container.id ??
             "mapillary-fallback-container-id";
@@ -116,6 +122,8 @@ export class Container {
 
         this.spriteService =
             new SpriteService(options.sprite);
+
+        window.addEventListener('resize', this._onWindowResize, false);
     }
 
     public get canvas(): HTMLCanvasElement {
@@ -136,6 +144,8 @@ export class Container {
     }
 
     public remove(): void {
+        window.removeEventListener('resize', this._onWindowResize, false);
+
         this.spriteService.dispose();
         this.touchService.dispose();
         this.mouseService.dispose();
@@ -150,6 +160,12 @@ export class Container {
 
         this._container.classList
             .remove("mapillary-viewer");
+    }
+
+    private _onWindowResize = () => {
+        if (this._trackResize) {
+            this.renderService.resize$.next();
+        }
     }
 
     private _removeNode(node: Node): void {

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -747,7 +747,7 @@ export class Viewer extends EventEmitter implements IViewer {
      * ```
      */
     public resize(): void {
-        this._container.renderService.resize$.next(null);
+        this._container.renderService.resize$.next();
     }
 
     /**

--- a/src/viewer/options/ViewerOptions.ts
+++ b/src/viewer/options/ViewerOptions.ts
@@ -76,10 +76,12 @@ export interface ViewerOptions {
     sprite?: string;
 
     /**
-     * Optional user bearer token for API requests of
-     * protected resources.
+     * If `true`, the viewer will automatically resize when the
+     * browser window resizes.
+     *
+     * @default true
      */
-    userToken?: string;
+    trackResize?: boolean;
 
     /**
      * The transtion mode in the viewer.
@@ -91,4 +93,10 @@ export interface ViewerOptions {
      * The URL options.
      */
     url?: UrlOptions;
+
+    /**
+     * Optional user bearer token for API requests of
+     * protected resources.
+     */
+    userToken?: string;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Simplify common library usage

## Contribution

Add viewer option for tacking window resize, active by default. This removes the need for the library user to add a custom window resize handler. 

## Test Plan
```
yarn prepare
yarn test
yarn start
```
