### PR TITLE
Populate mouse event basic point for street controls only

### DIFF
--- a/src/viewer/Observer.ts
+++ b/src/viewer/Observer.ts
@@ -36,6 +36,7 @@ import { ViewerImageEvent } from "./events/ViewerImageEvent";
 import { ViewerNavigationEdgeEvent } from "./events/ViewerNavigationEdgeEvent";
 import { ViewerStateEvent } from "./events/ViewerStateEvent";
 import { ViewerBearingEvent } from "./events/ViewerBearingEvent";
+import { State } from "../state/State";
 
 type UnprojectionParams = [
     [
@@ -45,6 +46,7 @@ type UnprojectionParams = [
     RenderCamera,
     LngLatAlt,
     Transform,
+    State,
 ]
 
 export class Observer {
@@ -294,9 +296,10 @@ export class Observer {
                 withLatestFrom(
                     this._container.renderService.renderCamera$,
                     this._navigator.stateService.reference$,
-                    this._navigator.stateService.currentTransform$),
+                    this._navigator.stateService.currentTransform$,
+                    this._navigator.stateService.state$),
                 map(
-                    ([[type, event], render, reference, transform]
+                    ([[type, event], render, reference, transform, state]
                         : UnprojectionParams)
                         : ViewerMouseEvent => {
                         const unprojection: Unprojection =
@@ -307,8 +310,11 @@ export class Observer {
                                 reference,
                                 transform);
 
+                        const basicPoint = state === State.Traversing ?
+                            unprojection.basicPoint : null;
+
                         return {
-                            basicPoint: unprojection.basicPoint,
+                            basicPoint,
                             lngLat: unprojection.lngLat,
                             originalEvent: event,
                             pixelPoint: unprojection.pixelPoint,

--- a/src/viewer/events/ViewerMouseEvent.ts
+++ b/src/viewer/events/ViewerMouseEvent.ts
@@ -27,6 +27,10 @@ export interface ViewerMouseEvent extends ViewerEvent {
      * the border of a image. In that case the basic coordinates will be
      * `null`.
      *
+     * The basic point is only provided when the
+     * {@link CameraControls.Street} mode is active. For all other camera
+     * control modes, the basic point will be `null`.
+     *
      * Basic coordinates are 2D coordinates on the [0, 1] interval
      * and has the origin point, (0, 0), at the top left corner and the
      * maximum value, (1, 1), at the bottom right corner of the original


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Basic coordinates are only relevant in the position of the camera origin.

## Contribution

Return `null` for mouse event `basicPoint` property for other camera control modes than street

## Test Plan

```
yarn lint
yarn build
yarn test
yarn start
```
