### PR TITLE
Fix rendering for spherical images with non valid scale

### DIFF
--- a/src/component/util/MeshFactory.ts
+++ b/src/component/util/MeshFactory.ts
@@ -451,7 +451,9 @@ export class MeshFactory {
     private _getFlatImageSphereGeo(transform: Transform): THREE.BufferGeometry {
         const geometry =
             new THREE.SphereGeometry(this._imageSphereRadius, 20, 40);
-        const t = transform.srtInverse;
+        const t = transform.rt
+            .clone()
+            .invert();
         geometry.applyMatrix4(t);
         return geometry;
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensure that spherical images with non valid scale are rendered correctly.

## Contribution

- Do not use arbitrary scale fallback mesh creation, create fixed size sphere instead (introduce in https://github.com/mapillary/mapillary-js/commit/d7417c0dded65343531b6d8d02ffe7f8b81d8a4e#diff-f5b1bb034900d69405c09b5dd48afb8ad85312f0b6a0363c7bc36c49542b0a76R456

## Test Plan

```
yarn lint 
yarn build
yarn test
yarn start
```
