### PR TITLE
Subscribe to pointer instead of mouse events

### DIFF
--- a/src/component/sequence/SequenceDOMRenderer.ts
+++ b/src/component/sequence/SequenceDOMRenderer.ts
@@ -214,8 +214,8 @@ export class SequenceDOMRenderer {
             onchange: onPosition,
             oninput: onPosition,
             onkeydown: onKeyDown,
-            onmousedown: onStart,
-            onmousemove: onMove,
+            onpointerdown: onStart,
+            onpointermove: onMove,
             ontouchmove: onMove,
             ontouchstart: onStart,
             style: {
@@ -275,8 +275,8 @@ export class SequenceDOMRenderer {
                 onchange: onSpeed,
                 oninput: onSpeed,
                 onkeydown: onKeyDown,
-                onmousedown: onStart,
-                onmousemove: onMove,
+                onpointerdown: onStart,
+                onpointermove: onMove,
                 ontouchmove: onMove,
                 ontouchstart: onStart,
                 style: {
@@ -450,8 +450,8 @@ export class SequenceDOMRenderer {
                             });
                 } :
                 null,
-            onmouseenter: (): void => { this._mouseEnterDirection$.next(NavigationDirection.Next); },
-            onmouseleave: (): void => { this._mouseLeaveDirection$.next(NavigationDirection.Next); },
+            onpointerenter: (): void => { this._mouseEnterDirection$.next(NavigationDirection.Next); },
+            onpointerleave: (): void => { this._mouseLeaveDirection$.next(NavigationDirection.Next); },
         };
 
         const borderRadius: number = Math.round(8 / this._stepperDefaultWidth * containerWidth);
@@ -468,8 +468,8 @@ export class SequenceDOMRenderer {
                             });
                 } :
                 null,
-            onmouseenter: (): void => { this._mouseEnterDirection$.next(NavigationDirection.Prev); },
-            onmouseleave: (): void => { this._mouseLeaveDirection$.next(NavigationDirection.Prev); },
+            onpointerenter: (): void => { this._mouseEnterDirection$.next(NavigationDirection.Prev); },
+            onpointerleave: (): void => { this._mouseLeaveDirection$.next(NavigationDirection.Prev); },
             style: {
                 "border-bottom-left-radius": `${borderRadius}px`,
                 "border-top-left-radius": `${borderRadius}px`,

--- a/src/component/slider/SliderDOMRenderer.ts
+++ b/src/component/slider/SliderDOMRenderer.ts
@@ -158,8 +158,8 @@ export class SliderDOMRenderer {
                 onchange: onChange,
                 oninput: onChange,
                 onkeydown: onKeyDown,
-                onmousedown: onStart,
-                onmousemove: onMove,
+                onpointerdown: onStart,
+                onpointermove: onMove,
                 ontouchmove: onMove,
                 ontouchstart: onStart,
                 style: {

--- a/src/component/spatial/SpatialComponent.ts
+++ b/src/component/spatial/SpatialComponent.ts
@@ -444,7 +444,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
                     ([playing, mouseHover]:
                         [boolean, IntersectEvent, boolean, FilterFunction])
                         : Observable<[IntersectEvent, RenderCamera, IntersectConfiguration]> => {
-                        return !playing && mouseHover.type === "mouseenter" ?
+                        return !playing && mouseHover.type === "pointerenter" ?
                             observableCombineLatest(
                                 observableConcat(
                                     mouseMove$.pipe(take(1)),
@@ -459,7 +459,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
             .subscribe(
                 ([event, render]
                     : [IntersectEvent, RenderCamera, IntersectConfiguration]): void => {
-                    if (event.type !== "mousemove") {
+                    if (event.type !== "pointermove") {
                         this._scene.setHoveredImage(null);
                         return;
                     }

--- a/src/component/tag/tag/ExtremePointRenderTag.ts
+++ b/src/component/tag/tag/ExtremePointRenderTag.ts
@@ -76,7 +76,7 @@ export class ExtremePointRenderTag extends OutlineRenderTagBase<ExtremePointTag>
             const transform: string = `translate(-50%, -50%) translate(${vertexCanvasX}px,${vertexCanvasY}px)`;
 
             const properties: vd.createProperties = {
-                onmousedown: interact,
+                onpointerdown: interact,
                 style: { background: lineColor, transform: transform, cursor: cursor },
             };
 

--- a/src/component/tag/tag/OutlineRenderTag.ts
+++ b/src/component/tag/tag/OutlineRenderTag.ts
@@ -88,7 +88,7 @@ export class OutlineRenderTag extends OutlineRenderTagBase<OutlineTag> {
 
                     const properties: vd.createProperties = {
                         onclick: click,
-                        onmousedown: interact,
+                        onpointerdown: interact,
                         style: { transform: transform },
                     };
 
@@ -120,7 +120,7 @@ export class OutlineRenderTag extends OutlineRenderTagBase<OutlineTag> {
                 };
 
                 const properties: vd.createProperties = {
-                    onmousedown: interact,
+                    onpointerdown: interact,
                     style: {
                         color: this._colorToCss(this._tag.textColor),
                         transform: transform,
@@ -155,7 +155,7 @@ export class OutlineRenderTag extends OutlineRenderTagBase<OutlineTag> {
                 const transform: string = `translate(-50%, -50%) translate(${centroidCanvasX}px,${centroidCanvasY}px)`;
 
                 const properties: vd.createProperties = {
-                    onmousedown: interact,
+                    onpointerdown: interact,
                     style: { background: lineColor, transform: transform },
                 };
 
@@ -195,7 +195,7 @@ export class OutlineRenderTag extends OutlineRenderTagBase<OutlineTag> {
             const transform: string = `translate(-50%, -50%) translate(${vertexCanvasX}px,${vertexCanvasY}px)`;
 
             const properties: vd.createProperties = {
-                onmousedown: interact,
+                onpointerdown: interact,
                 style: { background: lineColor, transform: transform, cursor: cursor },
             };
 

--- a/src/component/tag/tag/OutlineRenderTagBase.ts
+++ b/src/component/tag/tag/OutlineRenderTagBase.ts
@@ -166,7 +166,7 @@ export abstract class OutlineRenderTagBase<T extends Tag> extends RenderTag<T> {
             attribute.set(positions);
             attribute.needsUpdate = true;
         } else {
-            geometry.removeAttribute("position");
+            geometry.deleteAttribute("position");
             geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
         }
 

--- a/src/component/tag/tag/SpotRenderTag.ts
+++ b/src/component/tag/tag/SpotRenderTag.ts
@@ -48,7 +48,7 @@ export class SpotRenderTag extends RenderTag<SpotTag> {
                     const sprite: vd.VNode = atlas.getDOMSprite(tag.icon, Alignment.Bottom);
                     const iconTransform: string = `translate(${canvasX}px,${canvasY + 8}px)`;
                     const properties: vd.createProperties = {
-                        onmousedown: interactNone,
+                        onpointerdown: interactNone,
                         style: {
                             pointerEvents: "all",
                             transform: iconTransform,
@@ -60,7 +60,7 @@ export class SpotRenderTag extends RenderTag<SpotTag> {
             } else if (tag.text != null) {
                 const textTransform: string = `translate(-50%,0%) translate(${canvasX}px,${canvasY + 8}px)`;
                 const properties: vd.createProperties = {
-                    onmousedown: interactNone,
+                    onpointerdown: interactNone,
                     style: {
                         color: this._colorToCss(tag.textColor),
                         transform: textTransform,
@@ -77,7 +77,7 @@ export class SpotRenderTag extends RenderTag<SpotTag> {
 
             if (tag.editable) {
                 let interactorProperties: vd.createProperties = {
-                    onmousedown: interact,
+                    onpointerdown: interact,
                     style: {
                         background: background,
                         transform: transform,

--- a/test/helper/EventHelper.ts
+++ b/test/helper/EventHelper.ts
@@ -5,9 +5,9 @@ export class EventHelper {
 
     public static createMouseEvent(
         eventType: string,
-        params: MouseEventInit,
+        params: PointerEventInit,
         target?: EventTarget): MouseEvent {
-        return new MouseEvent(
+        const event = new MouseEvent(
             eventType,
             {
                 bubbles: params.bubbles !== undefined ?
@@ -28,6 +28,10 @@ export class EventHelper {
                 relatedTarget: !!target ?
                     target : document.createElement("div"),
             });
+
+        // Workaround for pointer event not existing in JSDom
+        (<any>event).pointerType = params.pointerType ?? "mouse";
+        return event;
     }
 
     public static createTouchEvent(eventType: string, shiftKey?: boolean): TouchEvent {

--- a/test/viewer/MouseService.test.ts
+++ b/test/viewer/MouseService.test.ts
@@ -4,38 +4,122 @@ import { EventHelper } from "../helper/EventHelper";
 import { MouseService } from "../../src/viewer/MouseService";
 
 describe("MouseService.ctor", () => {
-    it("should be definded", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should be definded", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         expect(mouseService).toBeDefined();
     });
 });
 
+describe("MouseService.mouseDown$", () => {
+    test("should emit mouse down for mouse pointer type", done => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
+
+        const mouseService = new MouseService(
+            container,
+            canvasContainer,
+            domContainer,
+            doc);
+
+        mouseService.mouseDown$
+            .subscribe(
+                (event: PointerEvent): void => {
+                    expect(event.type).toBe("pointerdown");
+                    expect(event.pointerType).toBe("mouse");
+                    done();
+                });
+
+        const mouseDownEvent = EventHelper.createMouseEvent(
+            "pointerdown",
+            { button: 0, pointerType: "mouse" },
+            canvasContainer);
+
+        canvasContainer.dispatchEvent(mouseDownEvent);
+    });
+
+    test("should emit mouse down for pen pointer type", done => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
+
+        const mouseService = new MouseService(
+            container,
+            canvasContainer,
+            domContainer,
+            doc);
+
+        mouseService.mouseDown$
+            .subscribe(
+                (event: PointerEvent): void => {
+                    expect(event.type).toBe("pointerdown");
+                    expect(event.pointerType).toBe("pen");
+                    done();
+                });
+
+        const mouseDownEvent = EventHelper.createMouseEvent(
+            "pointerdown",
+            { button: 0, pointerType: "pen" },
+            canvasContainer);
+
+        canvasContainer.dispatchEvent(mouseDownEvent);
+    });
+
+    test("should not emit mouse down for touch pointer type", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
+
+        const mouseService = new MouseService(
+            container,
+            canvasContainer,
+            domContainer,
+            doc);
+
+        mouseService.mouseDown$
+            .subscribe(
+                (): void => {
+                    fail();
+                });
+
+        const mouseDownEvent = EventHelper.createMouseEvent(
+            "pointerdown",
+            { button: 0, pointerType: "touch" },
+            canvasContainer);
+
+        canvasContainer.dispatchEvent(mouseDownEvent);
+    });
+});
+
 describe("MouseService.mouseDragStart$", () => {
-    it("should emit mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
                     expect(event.button === 0);
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         doc.dispatchEvent(mouseMoveEvent);
         expect(mouseDragStartEmitCount).toBe(0);
@@ -46,23 +130,23 @@ describe("MouseService.mouseDragStart$", () => {
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should not emit mouse drag start when not left button", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit mouse drag start when not left button", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 1 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 1 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         doc.dispatchEvent(mouseMoveEvent);
@@ -72,24 +156,24 @@ describe("MouseService.mouseDragStart$", () => {
 });
 
 describe("MouseService.mouseDrag$", () => {
-    it("should emit mouse drag", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit mouse drag", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDragEmitCount: number = 0;
+        let mouseDragEmitCount = 0;
         mouseService.mouseDrag$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragEmitCount++;
-                    expect(event.type).toBe("mousemove");
+                    expect(event.type).toBe("pointermove");
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         doc.dispatchEvent(mouseMoveEvent);
         expect(mouseDragEmitCount).toBe(0);
@@ -103,22 +187,22 @@ describe("MouseService.mouseDrag$", () => {
         expect(mouseDragEmitCount).toBe(2);
     });
 
-    it("should emit mouse drag after mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit mouse drag after mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDragEmitCount: number = 0;
+        let mouseDragEmitCount = 0;
         mouseService.mouseDrag$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragEmitCount++;
                 });
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -126,8 +210,8 @@ describe("MouseService.mouseDrag$", () => {
                     mouseDragStartEmitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
@@ -138,15 +222,15 @@ describe("MouseService.mouseDrag$", () => {
         expect(mouseDragEmitCount).toBe(1);
     });
 
-    it("should emit mouse drag after switch mapping from mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit mouse drag after switch mapping from mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let emitCount: number = 0;
+        let emitCount = 0;
         mouseService.mouseDragStart$.pipe(
             switchMap(
                 (e: MouseEvent): Observable<MouseEvent> => {
@@ -157,8 +241,8 @@ describe("MouseService.mouseDrag$", () => {
                     emitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, doc);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, doc);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(emitCount).toBe(0);
@@ -173,17 +257,17 @@ describe("MouseService.mouseDrag$", () => {
         expect(emitCount).toBe(3);
     });
 
-    it("should emit filtered mouse drag after switch mapping from filtered mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit filtered mouse drag after switch mapping from filtered mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.claimMouse("test", 1);
 
-        let emitCount: number = 0;
+        let emitCount = 0;
         mouseService
             .filtered$("test", mouseService.mouseDragStart$).pipe(
                 switchMap(
@@ -195,8 +279,8 @@ describe("MouseService.mouseDrag$", () => {
                     emitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(emitCount).toBe(0);
@@ -213,13 +297,13 @@ describe("MouseService.mouseDrag$", () => {
 });
 
 describe("MouseService.mouseDragEnd$", () => {
-    it("should emit mouse drag end on mouse up", (done: Function) => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit mouse drag end on mouse up", (done: Function) => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.mouseDragEnd$
             .subscribe(
@@ -227,22 +311,22 @@ describe("MouseService.mouseDragEnd$", () => {
                     done();
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
-        const mouseUpEvent: MouseEvent = EventHelper.createMouseEvent("mouseup", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
+        const mouseUpEvent = EventHelper.createMouseEvent("pointerup", {}, document);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         doc.dispatchEvent(mouseMoveEvent);
         doc.dispatchEvent(mouseUpEvent);
     });
 
-    it("should emit mouse drag end on window blur", (done: Function) => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit mouse drag end on window blur", (done: Function) => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.mouseDragEnd$
             .subscribe(
@@ -250,8 +334,8 @@ describe("MouseService.mouseDragEnd$", () => {
                     done();
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
         const blurEvent: UIEvent = EventHelper.createUIEvent("blur");
 
         canvasContainer.dispatchEvent(mouseDownEvent);
@@ -261,25 +345,25 @@ describe("MouseService.mouseDragEnd$", () => {
 });
 
 describe("MouseService.domMouseDragStart$", () => {
-    it("should emit DOM mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit DOM mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let domMouseDragStartEmitCount: number = 0;
+        let domMouseDragStartEmitCount = 0;
         mouseService.domMouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     domMouseDragStartEmitCount++;
                     expect(event.button === 0);
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         doc.dispatchEvent(mouseMoveEvent);
         expect(domMouseDragStartEmitCount).toBe(0);
@@ -290,23 +374,23 @@ describe("MouseService.domMouseDragStart$", () => {
         expect(domMouseDragStartEmitCount).toBe(1);
     });
 
-    it("should not emit DOM mouse drag start when not left button", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit DOM mouse drag start when not left button", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let domMouseDragStartEmitCount: number = 0;
+        let domMouseDragStartEmitCount = 0;
         mouseService.domMouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     domMouseDragStartEmitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 1 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 1 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         domContainer.dispatchEvent(mouseDownEvent);
         doc.dispatchEvent(mouseMoveEvent);
@@ -316,24 +400,24 @@ describe("MouseService.domMouseDragStart$", () => {
 });
 
 describe("MouseService.domMouseDrag$", () => {
-    it("should emit DOM mouse drag", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit DOM mouse drag", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let domMouseDragEmitCount: number = 0;
+        let domMouseDragEmitCount = 0;
         mouseService.domMouseDrag$
             .subscribe(
                 (event: MouseEvent): void => {
                     domMouseDragEmitCount++;
-                    expect(event.type).toBe("mousemove");
+                    expect(event.type).toBe("pointermove");
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         doc.dispatchEvent(mouseMoveEvent);
         expect(domMouseDragEmitCount).toBe(0);
@@ -347,22 +431,22 @@ describe("MouseService.domMouseDrag$", () => {
         expect(domMouseDragEmitCount).toBe(2);
     });
 
-    it("should emit DOM mouse drag after DOM mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit DOM mouse drag after DOM mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let domMouseDragEmitCount: number = 0;
+        let domMouseDragEmitCount = 0;
         mouseService.domMouseDrag$
             .subscribe(
                 (event: MouseEvent): void => {
                     domMouseDragEmitCount++;
                 });
 
-        let domMouseDragStartEmitCount: number = 0;
+        let domMouseDragStartEmitCount = 0;
         mouseService.domMouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -370,8 +454,8 @@ describe("MouseService.domMouseDrag$", () => {
                     domMouseDragStartEmitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         domContainer.dispatchEvent(mouseDownEvent);
         expect(domMouseDragStartEmitCount).toBe(0);
@@ -382,15 +466,15 @@ describe("MouseService.domMouseDrag$", () => {
         expect(domMouseDragEmitCount).toBe(1);
     });
 
-    it("should emit DOM mouse drag after switch mapping from DOM mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit DOM mouse drag after switch mapping from DOM mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let emitCount: number = 0;
+        let emitCount = 0;
         mouseService.domMouseDragStart$.pipe(
             switchMap(
                 (e: MouseEvent): Observable<MouseEvent> => {
@@ -401,8 +485,8 @@ describe("MouseService.domMouseDrag$", () => {
                     emitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, doc);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, doc);
 
         domContainer.dispatchEvent(mouseDownEvent);
         expect(emitCount).toBe(0);
@@ -417,17 +501,17 @@ describe("MouseService.domMouseDrag$", () => {
         expect(emitCount).toBe(3);
     });
 
-    it("should emit filtered DOM ouse drag after switch mapping from DOM filtered mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit filtered DOM ouse drag after switch mapping from DOM filtered mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.claimMouse("test", 1);
 
-        let emitCount: number = 0;
+        let emitCount = 0;
         mouseService
             .filtered$("test", mouseService.domMouseDragStart$).pipe(
                 switchMap(
@@ -439,8 +523,8 @@ describe("MouseService.domMouseDrag$", () => {
                     emitCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
 
         domContainer.dispatchEvent(mouseDownEvent);
         expect(emitCount).toBe(0);
@@ -457,13 +541,13 @@ describe("MouseService.domMouseDrag$", () => {
 });
 
 describe("MouseService.domMouseDragEnd$", () => {
-    it("should emit DOM mouse drag end on DOM mouse up", (done: Function) => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit DOM mouse drag end on DOM mouse up", (done: Function) => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.domMouseDragEnd$
             .subscribe(
@@ -471,22 +555,22 @@ describe("MouseService.domMouseDragEnd$", () => {
                     done();
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
-        const mouseUpEvent: MouseEvent = EventHelper.createMouseEvent("mouseup", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
+        const mouseUpEvent = EventHelper.createMouseEvent("pointerup", {}, document);
 
         domContainer.dispatchEvent(mouseDownEvent);
         doc.dispatchEvent(mouseMoveEvent);
         doc.dispatchEvent(mouseUpEvent);
     });
 
-    it("should emit DOM mouse drag end on window blur", (done: Function) => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit DOM mouse drag end on window blur", (done: Function) => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.domMouseDragEnd$
             .subscribe(
@@ -494,8 +578,8 @@ describe("MouseService.domMouseDragEnd$", () => {
                     done();
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, domContainer);
-        const mouseMoveEvent: MouseEvent = EventHelper.createMouseEvent("mousemove", {}, document);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, domContainer);
+        const mouseMoveEvent = EventHelper.createMouseEvent("pointermove", {}, document);
         const blurEvent: UIEvent = EventHelper.createUIEvent("blur");
 
         domContainer.dispatchEvent(mouseDownEvent);
@@ -505,13 +589,13 @@ describe("MouseService.domMouseDragEnd$", () => {
 });
 
 describe("MouseService.claimMouse", () => {
-    it("should emit filtered after claiming mouse", (done: Function) => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit filtered after claiming mouse", (done: Function) => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.claimMouse("test", 0);
         mouseService.filtered$("test", mouseService.mouseDown$)
@@ -521,42 +605,42 @@ describe("MouseService.claimMouse", () => {
                     done();
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
     });
 
-    it("should not emit filtered if not claimed", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit filtered if not claimed", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDownCount: number = 0;
+        let mouseDownCount = 0;
         mouseService.filtered$("test", mouseService.mouseDown$)
             .subscribe(
                 (mouseDown: MouseEvent): void => {
                     mouseDownCount++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
 
         expect(mouseDownCount).toBe(0);
     });
 
-    it("should emit to highest z-index", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit to highest z-index", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDownCount1: number = 0;
+        let mouseDownCount1 = 0;
         mouseService.claimMouse("test1", 1);
         mouseService.filtered$("test1", mouseService.mouseDown$)
             .subscribe(
@@ -564,7 +648,7 @@ describe("MouseService.claimMouse", () => {
                     mouseDownCount1++;
                 });
 
-        let mouseDownCount2: number = 0;
+        let mouseDownCount2 = 0;
         mouseService.claimMouse("test2", 2);
         mouseService.filtered$("test2", mouseService.mouseDown$)
             .subscribe(
@@ -572,7 +656,7 @@ describe("MouseService.claimMouse", () => {
                     mouseDownCount2++;
                 });
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
 
@@ -580,15 +664,15 @@ describe("MouseService.claimMouse", () => {
         expect(mouseDownCount2).toBe(1);
     });
 
-    it("should emit to lower z-index after higher z-index unclaims", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit to lower z-index after higher z-index unclaims", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDownCount1: number = 0;
+        let mouseDownCount1 = 0;
         mouseService.claimMouse("test1", 1);
         mouseService.filtered$("test1", mouseService.mouseDown$)
             .subscribe(
@@ -596,7 +680,7 @@ describe("MouseService.claimMouse", () => {
                     mouseDownCount1++;
                 });
 
-        let mouseDownCount2: number = 0;
+        let mouseDownCount2 = 0;
         mouseService.claimMouse("test2", 2);
         mouseService.filtered$("test2", mouseService.mouseDown$)
             .subscribe(
@@ -606,7 +690,7 @@ describe("MouseService.claimMouse", () => {
 
         mouseService.unclaimMouse("test2");
 
-        const mouseDownEvent: MouseEvent = EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
+        const mouseDownEvent = EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
 
@@ -616,13 +700,13 @@ describe("MouseService.claimMouse", () => {
 });
 
 describe("MouseService.claimWheel", () => {
-    it("should emit filtered after claiming wheel", (done: Function) => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit filtered after claiming wheel", (done: Function) => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.claimWheel("test", 0);
         mouseService.filteredWheel$("test", mouseService.mouseWheel$)
@@ -637,15 +721,15 @@ describe("MouseService.claimWheel", () => {
         canvasContainer.dispatchEvent(wheelEvent);
     });
 
-    it("should not emit filtered if not claimed", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit filtered if not claimed", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let wheelCount: number = 0;
+        let wheelCount = 0;
         mouseService.filteredWheel$("test", mouseService.mouseWheel$)
             .subscribe(
                 (wheel: WheelEvent): void => {
@@ -659,15 +743,15 @@ describe("MouseService.claimWheel", () => {
         expect(wheelCount).toBe(0);
     });
 
-    it("should emit to highest z-index", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit to highest z-index", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let wheelCount1: number = 0;
+        let wheelCount1 = 0;
         mouseService.claimWheel("test1", 1);
         mouseService.filteredWheel$("test1", mouseService.mouseWheel$)
             .subscribe(
@@ -675,7 +759,7 @@ describe("MouseService.claimWheel", () => {
                     wheelCount1++;
                 });
 
-        let wheelCount2: number = 0;
+        let wheelCount2 = 0;
         mouseService.claimWheel("test2", 2);
         mouseService.filteredWheel$("test2", mouseService.mouseWheel$)
             .subscribe(
@@ -691,15 +775,15 @@ describe("MouseService.claimWheel", () => {
         expect(wheelCount2).toBe(1);
     });
 
-    it("should emit to lower z-index after higher z-index unclaims", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit to lower z-index after higher z-index unclaims", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let wheelCount1: number = 0;
+        let wheelCount1 = 0;
         mouseService.claimWheel("test1", 1);
         mouseService.filteredWheel$("test1", mouseService.mouseWheel$)
             .subscribe(
@@ -707,7 +791,7 @@ describe("MouseService.claimWheel", () => {
                     wheelCount1++;
                 });
 
-        let wheelCount2: number = 0;
+        let wheelCount2 = 0;
         mouseService.claimWheel("test2", 2);
         mouseService.filteredWheel$("test2", mouseService.mouseWheel$)
             .subscribe(
@@ -727,26 +811,26 @@ describe("MouseService.claimWheel", () => {
 });
 
 describe("MouseService.deferPixels", () => {
-    it("should not defer mouse drag start if not specified", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not defer mouse drag start if not specified", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const mouseMoveEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
@@ -755,29 +839,29 @@ describe("MouseService.deferPixels", () => {
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should not defer mouse drag start if deferring and undeferring", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not defer mouse drag start if deferring and undeferring", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 10);
         mouseService.undeferPixels("test");
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const mouseMoveEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
@@ -786,304 +870,304 @@ describe("MouseService.deferPixels", () => {
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should emit when moving more than 1 pixel in x-direction if deferring 1 pixel", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit when moving more than 1 pixel in x-direction if deferring 1 pixel", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 1);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent1: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent1);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 51, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 51, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent2);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent3: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 52, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 52, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent3);
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should emit when moving more than 1 pixel in y-direction if deferring 1 pixel", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit when moving more than 1 pixel in y-direction if deferring 1 pixel", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 1);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent1: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent1);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 51 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 51 }, document);
         doc.dispatchEvent(mouseMoveEvent2);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent3: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 52 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 52 }, document);
         doc.dispatchEvent(mouseMoveEvent3);
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should emit when moving more than 1 pixel in diagonal direction if deferring 1 pixel", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit when moving more than 1 pixel in diagonal direction if deferring 1 pixel", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 1);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent1: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent1);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 49, clientY: 49 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 49, clientY: 49 }, document);
         doc.dispatchEvent(mouseMoveEvent2);
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should use largest supplied deferred pixel value", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should use largest supplied deferred pixel value", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test1", 2);
         mouseService.deferPixels("test2", 4);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 53, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 53, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent2);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent3: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 55, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 55, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent3);
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should use the largest value of the remaining after undeferring largest", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should use the largest value of the remaining after undeferring largest", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test1", 2);
         mouseService.deferPixels("test2", 4);
         mouseService.undeferPixels("test2");
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 53, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 53, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent2);
         expect(mouseDragStartEmitCount).toBe(1);
     });
 
-    it("should not emit when moving back towards mouse down position", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit when moving back towards mouse down position", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 5);
 
-        let mouseDragStartEmitCount: number = 0;
+        let mouseDragStartEmitCount = 0;
         mouseService.mouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent1: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 55, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 55, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent1);
         expect(mouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent2);
         expect(mouseDragStartEmitCount).toBe(0);
     });
 
-    it("should emit event of mouse move that passed pixel threshold for mouse drag", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit event of mouse move that passed pixel threshold for mouse drag", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 1);
 
-        let mouseDragEmitCount: number = 0;
+        let mouseDragEmitCount = 0;
         mouseService.mouseDrag$
             .subscribe(
                 (event: MouseEvent): void => {
                     mouseDragEmitCount++;
-                    expect(event.type).toBe("mousemove");
+                    expect(event.type).toBe("pointermove");
                     expect(event.clientX).toBe(52);
                     expect(event.clientY).toBe(53);
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
 
         canvasContainer.dispatchEvent(mouseDownEvent);
         expect(mouseDragEmitCount).toBe(0);
 
         const mouseMoveEvent1: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 51, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 51, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent1);
         expect(mouseDragEmitCount).toBe(0);
 
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 52, clientY: 53 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 52, clientY: 53 }, document);
         doc.dispatchEvent(mouseMoveEvent2);
         expect(mouseDragEmitCount).toBe(1);
     });
 
-    it("should not defer dom mouse drag start", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not defer dom mouse drag start", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 1);
 
-        let domMouseDragStartEmitCount: number = 0;
+        let domMouseDragStartEmitCount = 0;
         mouseService.domMouseDragStart$
             .subscribe(
                 (event: MouseEvent): void => {
                     domMouseDragStartEmitCount++;
-                    expect(event.type).toBe("mousedown");
+                    expect(event.type).toBe("pointerdown");
                     expect(event.clientX).toBe(50);
                     expect(event.clientY).toBe(50);
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, domContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, domContainer);
 
         domContainer.dispatchEvent(mouseDownEvent);
         expect(domMouseDragStartEmitCount).toBe(0);
 
         const mouseMoveEvent1: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
         doc.dispatchEvent(mouseMoveEvent1);
         expect(domMouseDragStartEmitCount).toBe(1);
     });
 });
 
 describe("MouseService.staticClick$", () => {
-    it("should emit if no mouse move occurs", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit if no mouse move occurs", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let staticClickCount: number = 0;
+        let staticClickCount = 0;
         mouseService.staticClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1092,7 +1176,7 @@ describe("MouseService.staticClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", {}, document);
 
@@ -1103,15 +1187,15 @@ describe("MouseService.staticClick$", () => {
         expect(staticClickCount).toBe(1);
     });
 
-    it("should not emit if mouse move is emitted before click irrespective of coordinates", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit if mouse move is emitted before click irrespective of coordinates", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let staticClickCount: number = 0;
+        let staticClickCount = 0;
         mouseService.staticClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1119,9 +1203,9 @@ describe("MouseService.staticClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0 }, canvasContainer);
         const mouseMoveEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", {}, document);
+            EventHelper.createMouseEvent("pointermove", {}, document);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", {}, document);
 
@@ -1137,15 +1221,15 @@ describe("MouseService.staticClick$", () => {
 });
 
 describe("MouseService.proximateClick$", () => {
-    it("should emit if no mouse move occurs if deferred pixels not specified", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit if no mouse move occurs if deferred pixels not specified", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let proximateClickCount: number = 0;
+        let proximateClickCount = 0;
         mouseService.proximateClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1154,7 +1238,7 @@ describe("MouseService.proximateClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", { clientX: 50, clientY: 50 }, document);
 
@@ -1165,18 +1249,18 @@ describe("MouseService.proximateClick$", () => {
         expect(proximateClickCount).toBe(1);
     });
 
-    it("should emit if deferring and undeferring", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit if deferring and undeferring", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 10);
         mouseService.undeferPixels("test");
 
-        let proximateClickCount: number = 0;
+        let proximateClickCount = 0;
         mouseService.proximateClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1185,7 +1269,7 @@ describe("MouseService.proximateClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", { clientX: 50, clientY: 50 }, document);
 
@@ -1196,15 +1280,15 @@ describe("MouseService.proximateClick$", () => {
         expect(proximateClickCount).toBe(1);
     });
 
-    it("should not emit if mouse move is emitted if deferred pixels not specified", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit if mouse move is emitted if deferred pixels not specified", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
-        let proximateClickCount: number = 0;
+        let proximateClickCount = 0;
         mouseService.proximateClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1212,9 +1296,9 @@ describe("MouseService.proximateClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const mouseMoveEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", { clientX: 50, clientY: 50 }, document);
 
@@ -1228,17 +1312,17 @@ describe("MouseService.proximateClick$", () => {
         expect(proximateClickCount).toBe(0);
     });
 
-    it("should emit if not moving outside deferred pixel threshold", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should emit if not moving outside deferred pixel threshold", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 4);
 
-        let proximateClickCount: number = 0;
+        let proximateClickCount = 0;
         mouseService.proximateClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1249,9 +1333,9 @@ describe("MouseService.proximateClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const mouseMoveEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 52, clientY: 51 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 52, clientY: 51 }, document);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", { clientX: 52, clientY: 51 }, document);
 
@@ -1265,17 +1349,17 @@ describe("MouseService.proximateClick$", () => {
         expect(proximateClickCount).toBe(1);
     });
 
-    it("should not emit if moving outside deferred pixel threshold", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit if moving outside deferred pixel threshold", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 1);
 
-        let proximateClickCount: number = 0;
+        let proximateClickCount = 0;
         mouseService.proximateClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1283,9 +1367,9 @@ describe("MouseService.proximateClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const mouseMoveEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 52, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 52, clientY: 50 }, document);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", { clientX: 52, clientY: 50 }, document);
 
@@ -1299,17 +1383,17 @@ describe("MouseService.proximateClick$", () => {
         expect(proximateClickCount).toBe(0);
     });
 
-    it("should not emit if moving outside deferred pixel threshold and then inside again", () => {
-        const container: HTMLElement = document.createElement("div");
-        const canvasContainer: HTMLElement = document.createElement("div");
-        const domContainer: HTMLElement = document.createElement("div");
-        const doc: HTMLElement = document.createElement("div");
+    test("should not emit if moving outside deferred pixel threshold and then inside again", () => {
+        const container = document.createElement("div");
+        const canvasContainer = document.createElement("div");
+        const domContainer = document.createElement("div");
+        const doc = document.createElement("div");
 
-        const mouseService: MouseService = new MouseService(container, canvasContainer, domContainer, doc);
+        const mouseService = new MouseService(container, canvasContainer, domContainer, doc);
 
         mouseService.deferPixels("test", 1);
 
-        let proximateClickCount: number = 0;
+        let proximateClickCount = 0;
         mouseService.proximateClick$
             .subscribe(
                 (event: MouseEvent): void => {
@@ -1317,11 +1401,11 @@ describe("MouseService.proximateClick$", () => {
                 });
 
         const mouseDownEvent: MouseEvent =
-            EventHelper.createMouseEvent("mousedown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
+            EventHelper.createMouseEvent("pointerdown", { button: 0, clientX: 50, clientY: 50 }, canvasContainer);
         const mouseMoveEvent1: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 52, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 52, clientY: 50 }, document);
         const mouseMoveEvent2: MouseEvent =
-            EventHelper.createMouseEvent("mousemove", { clientX: 50, clientY: 50 }, document);
+            EventHelper.createMouseEvent("pointermove", { clientX: 50, clientY: 50 }, document);
         const clickEvent: MouseEvent =
             EventHelper.createMouseEvent("click", { clientX: 50, clientY: 50 }, document);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Use relevant event to support other pointer types than mouse.

## Contribution

- Subscribe to pointer events instead of mouse events everywhere

## Test Plan

```
yarn build
yarn test
yarn start
```
