### PR TITLE
Require normalized cluster point colors

### DIFF
--- a/src/api/contracts/PointContract.ts
+++ b/src/api/contracts/PointContract.ts
@@ -5,7 +5,8 @@
  */
 export interface PointContract {
     /**
-     * RGB color vector of the point.
+     * RGB color vector of the point, normalized to floats
+     * on the interval [0, 1];
      */
     color: number[];
 

--- a/src/api/falcor/FalcorConverter.ts
+++ b/src/api/falcor/FalcorConverter.ts
@@ -75,6 +75,14 @@ export class FalcorConverter {
         item: FalcorClusterContract): ClusterContract {
         const id: string = null;
         const points = item.points;
+        const normalize = 1 / 255;
+        for (const point of Object.values(points)) {
+            const color = point.color;
+            color[0] *= normalize;
+            color[1] *= normalize;
+            color[2] *= normalize;
+        }
+
         const lla = item.reference_lla;
         const reference: LngLatAlt = {
             alt: lla.altitude,

--- a/src/component/spatial/scene/ClusterPoints.ts
+++ b/src/component/spatial/scene/ClusterPoints.ts
@@ -49,7 +49,6 @@ export class ClusterPoints extends Points {
     private _makeAttributes(cluster: ClusterContract): void {
         const positions: number[] = [];
         const colors: number[] = [];
-        const normalize = 1 / 255;
 
         const points = cluster.points;
         for (const pointId in points) {
@@ -61,9 +60,9 @@ export class ClusterPoints extends Points {
             positions.push(...point.coordinates)
 
             const color = point.color;
-            colors.push(normalize * color[0]);
-            colors.push(normalize * color[1]);
-            colors.push(normalize * color[2]);
+            colors.push(color[0]);
+            colors.push(color[1]);
+            colors.push(color[2]);
         }
 
         const geometry = this.geometry;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Improve core MJS perf.

## Contribution

- Require color values to be normalized to [0, 1] interval to avoid muliplications.
- Move normalization to data provider (leads to a short term perf cost because of another for loop)

## Test Plan

```
yarn build
yarn test
yarn start
```
