### PR TITLE
Render visible items on spatial activation

### DIFF
--- a/examples/spatial.html
+++ b/examples/spatial.html
@@ -36,10 +36,11 @@
         } from './dist/mapillary.module.js';
 
         let cameraControls = CameraControls.Earth;
+        let spatialActive = true;
         const viewer = new Viewer({
             apiClient: "QjI1NnU0aG5FZFZISE56U3R5aWN4ZzpkYzg0NzE3MDA0YTRhZjlh",
             cameraControls,
-            component: { cover: false, spatial: true },
+            component: { cover: false, spatial: spatialActive },
             container: "mly",
         });
 
@@ -146,6 +147,7 @@
                     case 'p': name = 'pointsVisible'; break;
                     case 't': name = 'cellsVisible'; break;
                     case 'i': toggleImages(); break;
+                    case 'l': toggleSpatial(); break;
                     case 'c': rotateCvm(); break;
                     case 'o': rotatePm(); break;
                     case 'r': rotateCc(); break;
@@ -165,6 +167,12 @@
             if (s.imagesVisible) { viewer.activateComponent("image"); }
             else { viewer.deactivateComponent("image"); }
         }
+
+        function toggleSpatial() {
+            spatialActive = !spatialActive;
+            if (spatialActive) { viewer.activateComponent("spatial"); }
+            else { viewer.deactivateComponent("spatial"); }
+        };
 
         function toggleBooleanSetting(name) {
             s[name] = !s[name];

--- a/src/api/CellMath.ts
+++ b/src/api/CellMath.ts
@@ -1,0 +1,44 @@
+import { GeometryProvider } from "../../test/helper/ProviderHelper";
+
+export function connectedComponent(
+    cellId: string,
+    depth: number,
+    geometry: GeometryProvider)
+    : string[] {
+
+    const cells = new Set<string>();
+    cells.add(cellId);
+    connectedComponentRecursive(cells, [cellId], 0, depth, geometry);
+    return Array.from(cells);
+}
+
+function connectedComponentRecursive(
+    cells: Set<string>,
+    current: string[],
+    currentDepth: number,
+    maxDepth: number,
+    geometry: GeometryProvider)
+    : void {
+
+    if (currentDepth >= maxDepth) { return; }
+
+    const adjacent: string[] = [];
+    for (const cellId of current) {
+        const aCells = geometry.getAdjacent(cellId);
+        adjacent.push(...aCells);
+    }
+
+    const newCells: string[] = [];
+    for (const a of adjacent) {
+        if (cells.has(a)) { continue; }
+        cells.add(a);
+        newCells.push(a);
+    }
+
+    connectedComponentRecursive(
+        cells,
+        newCells,
+        currentDepth + 1,
+        maxDepth,
+        geometry);
+}

--- a/src/component/spatial/enums/CameraVisualizationMode.ts
+++ b/src/component/spatial/enums/CameraVisualizationMode.ts
@@ -1,7 +1,29 @@
 export enum CameraVisualizationMode {
+    /**
+     * Cameras are hidden.
+     */
     Hidden,
+
+    /**
+     * Cameras are shown, all with the same color.
+     */
     Homogeneous,
+
+    /**
+     * Cameras are shown with colors based on the
+     * their clusters.
+     */
     Cluster,
+
+    /**
+     * Cameras are shown with colors based on the
+     * their connected components.
+     */
     ConnectedComponent,
+
+    /**
+     * Cameras are shown, with colors based on the
+     * their sequence.
+     */
     Sequence,
 }

--- a/src/component/spatial/enums/OriginalPositionMode.ts
+++ b/src/component/spatial/enums/OriginalPositionMode.ts
@@ -1,17 +1,17 @@
 export enum OriginalPositionMode {
-  /**
-   * Original positions are hidden.
-   */
-  Hidden,
+    /**
+     * Original positions are hidden.
+     */
+    Hidden,
 
-  /**
-   * Visualize original positions with altitude change.
-   */
-  Altitude,
+    /**
+     * Visualize original positions with altitude change.
+     */
+    Altitude,
 
-  /**
-   * Visualize original positions without altitude change,
-   * i.e. as flat lines from the camera origin.
-   */
-  Flat,
+    /**
+     * Visualize original positions without altitude change,
+     * i.e. as flat lines from the camera origin.
+     */
+    Flat,
 }

--- a/src/graph/GraphService.ts
+++ b/src/graph/GraphService.ts
@@ -560,6 +560,7 @@ export class GraphService {
      * related to those images.
      *
      * @param {Array<string>} keepIds - Ids of images to keep in graph.
+     * @param {Array<string>} keepCellIds - Ids of cells to keep in graph.
      * @param {string} keepSequenceId - Optional id of sequence
      * for which the belonging images should not be disposed or
      * removed from the graph. These images may still be uncached if
@@ -567,12 +568,17 @@ export class GraphService {
      * @return {Observable<Graph>} Observable emitting a single item,
      * the graph, when the graph has been uncached.
      */
-    public uncache$(keepIds: string[], keepSequenceId?: string): Observable<void> {
+    public uncache$(
+        keepIds: string[],
+        keepCellIds: string[],
+        keepSequenceId?: string)
+        : Observable<void> {
+
         return this._graph$.pipe(
             first(),
             tap(
                 (graph: Graph): void => {
-                    graph.uncache(keepIds, keepSequenceId);
+                    graph.uncache(keepIds, keepCellIds, keepSequenceId);
                 }),
             map(
                 (): void => {

--- a/src/viewer/CacheService.ts
+++ b/src/viewer/CacheService.ts
@@ -24,24 +24,38 @@ import { NavigationEdgeStatus } from "../graph/interfaces/NavigationEdgeStatus";
 import { StateService } from "../state/StateService";
 import { AnimationFrame } from "../state/interfaces/AnimationFrame";
 import { SubscriptionHolder } from "../util/SubscriptionHolder";
+import { connectedComponent } from "../api/CellMath";
+import { LngLat } from "../external/api";
+import { APIWrapper } from "../api/APIWrapper";
+
+export interface CacheServiceConfiguration {
+    cellDepth: number;
+}
 
 export class CacheService {
-    private _graphService: GraphService;
-    private _stateService: StateService;
-
     private _subscriptions: SubscriptionHolder;
     private _started: boolean;
+    private _cellDepth: number;
 
-    constructor(graphService: GraphService, stateService: StateService) {
-        this._graphService = graphService;
-        this._stateService = stateService;
-
+    constructor(
+        private readonly _graphService: GraphService,
+        private readonly _stateService: StateService,
+        private readonly _api: APIWrapper) {
         this._subscriptions = new SubscriptionHolder()
         this._started = false;
+        this._cellDepth = 1;
     }
 
     public get started(): boolean {
         return this._started;
+    }
+
+    public configure(configuration?: CacheServiceConfiguration): void {
+        if (!configuration) {
+            this._cellDepth = 1;
+            return;
+        }
+        this._cellDepth = Math.max(1, Math.min(3, configuration.cellDepth));
     }
 
     public start(): void {
@@ -49,73 +63,92 @@ export class CacheService {
 
         const subs = this._subscriptions;
 
-        subs.push(this._stateService.currentState$.pipe(
-            distinctUntilChanged(
-                undefined,
-                (frame: AnimationFrame): string => {
-                    return frame.state.currentImage.id;
-                }),
-            map(
-                (frame: AnimationFrame): [string[], string] => {
-                    const trajectory: Image[] = frame.state.trajectory;
-                    const trajectoryKeys: string[] = trajectory
-                        .map(
-                            (n: Image): string => {
-                                return n.id;
-                            });
-
-                    const sequenceKey: string = trajectory[trajectory.length - 1].sequenceId;
-
-                    return [trajectoryKeys, sequenceKey];
-                }),
-            bufferCount(1, 5),
-            withLatestFrom(this._graphService.graphMode$),
-            switchMap(
-                ([keepBuffer, graphMode]: [[string[], string][], GraphMode]): Observable<void> => {
-                    let keepKeys: string[] = keepBuffer[0][0];
-                    let keepSequenceKey: string = graphMode === GraphMode.Sequence ?
-                        keepBuffer[0][1] : undefined;
-
-                    return this._graphService.uncache$(keepKeys, keepSequenceKey);
-                }))
-            .subscribe(() => { /*noop*/ }));
-
-        subs.push(this._graphService.graphMode$.pipe(
-            skip(1),
-            withLatestFrom(this._stateService.currentState$),
-            switchMap(
-                ([mode, frame]: [GraphMode, AnimationFrame]): Observable<NavigationEdgeStatus> => {
-                    return mode === GraphMode.Sequence ?
-                        this._keyToEdges(
-                            frame.state.currentImage.id,
-                            (image: Image): Observable<NavigationEdgeStatus> => {
-                                return image.sequenceEdges$;
-                            }) :
-                        observableFrom(frame.state.trajectory
+        subs.push(this._stateService.currentState$
+            .pipe(
+                distinctUntilChanged(
+                    undefined,
+                    (frame: AnimationFrame): string => {
+                        return frame.state.currentImage.id;
+                    }),
+                map(
+                    (frame: AnimationFrame): [string[], LngLat, string] => {
+                        const state = frame.state;
+                        const trajectory = state.trajectory;
+                        const trajectoryKeys = trajectory
                             .map(
-                                (image: Image): string => {
-                                    return image.id;
-                                })
-                            .slice(frame.state.currentIndex)).pipe(
-                                mergeMap(
-                                    (key: string): Observable<NavigationEdgeStatus> => {
-                                        return this._keyToEdges(
-                                            key,
-                                            (image: Image): Observable<NavigationEdgeStatus> => {
-                                                return image.spatialEdges$;
-                                            });
-                                    },
-                                    6));
-                }))
+                                (n: Image): string => {
+                                    return n.id;
+                                });
+
+                        const sequenceKey =
+                            trajectory[trajectory.length - 1].sequenceId;
+
+                        return [
+                            trajectoryKeys,
+                            state.currentImage.originalLngLat,
+                            sequenceKey,
+                        ];
+                    }),
+                bufferCount(1, 5),
+                withLatestFrom(this._graphService.graphMode$),
+                switchMap(
+                    ([keepBuffer, graphMode]: [[string[], LngLat, string][], GraphMode]): Observable<void> => {
+                        const keepKeys = keepBuffer[0][0];
+                        const lngLat = keepBuffer[0][1];
+                        const geometry = this._api.data.geometry;
+                        const cellId = geometry.lngLatToCellId(lngLat)
+                        const keepCellIds = connectedComponent(
+                            cellId, this._cellDepth, geometry);
+                        const keepSequenceKey =
+                            graphMode === GraphMode.Sequence ?
+                                keepBuffer[0][2] :
+                                undefined;
+
+                        return this._graphService
+                            .uncache$(keepKeys, keepCellIds, keepSequenceKey);
+                    }))
             .subscribe(() => { /*noop*/ }));
 
-        subs.push(this._graphService.dataAdded$.pipe(
-            withLatestFrom(this._stateService.currentId$),
-            switchMap(
-                ([_, imageId]: [string, string]): Observable<Image> => {
-                    return this._graphService.cacheImage$(imageId)
-                }))
-            .subscribe(() => { /*noop*/ }))
+        subs.push(this._graphService.graphMode$
+            .pipe(
+                skip(1),
+                withLatestFrom(this._stateService.currentState$),
+                switchMap(
+                    ([mode, frame]: [GraphMode, AnimationFrame]): Observable<NavigationEdgeStatus> => {
+                        return mode === GraphMode.Sequence ?
+                            this._keyToEdges(
+                                frame.state.currentImage.id,
+                                (image: Image)
+                                    : Observable<NavigationEdgeStatus> => {
+                                    return image.sequenceEdges$;
+                                }) :
+                            observableFrom(frame.state.trajectory
+                                .map(
+                                    (image: Image): string => {
+                                        return image.id;
+                                    })
+                                .slice(frame.state.currentIndex)).pipe(
+                                    mergeMap(
+                                        (key: string): Observable<NavigationEdgeStatus> => {
+                                            return this._keyToEdges(
+                                                key,
+                                                (image: Image): Observable<NavigationEdgeStatus> => {
+                                                    return image.spatialEdges$;
+                                                });
+                                        },
+                                        6));
+                    }))
+            .subscribe(() => { /*noop*/ }));
+
+        subs.push(
+            this._graphService.dataAdded$
+                .pipe(
+                    withLatestFrom(this._stateService.currentId$),
+                    switchMap(
+                        ([_, imageId]: [string, string]): Observable<Image> => {
+                            return this._graphService.cacheImage$(imageId)
+                        }))
+                .subscribe(() => { /*noop*/ }))
 
         this._started = true;
     }
@@ -127,7 +160,11 @@ export class CacheService {
         this._started = false;
     }
 
-    private _keyToEdges(key: string, imageToEdgeMap: (image: Image) => Observable<NavigationEdgeStatus>): Observable<NavigationEdgeStatus> {
+    private _keyToEdges(
+        key: string,
+        imageToEdgeMap: (image: Image) => Observable<NavigationEdgeStatus>)
+        : Observable<NavigationEdgeStatus> {
+
         return this._graphService.cacheImage$(key).pipe(
             switchMap(imageToEdgeMap),
             first(

--- a/src/viewer/Navigator.ts
+++ b/src/viewer/Navigator.ts
@@ -93,7 +93,10 @@ export class Navigator {
                 options.transitionMode);
 
         this._cacheService = cacheService ??
-            new CacheService(this._graphService, this._stateService);
+            new CacheService(
+                this._graphService,
+                this._stateService,
+                this._api);
 
         this._playService = playService ??
             new PlayService(this._graphService, this._stateService);

--- a/test/api/CellMath.test.ts
+++ b/test/api/CellMath.test.ts
@@ -1,0 +1,36 @@
+import { connectedComponent } from "../../src/api/CellMath";
+import { S2GeometryProvider } from "../../src/api/S2GeometryProvider";
+
+describe("connectedComponent", () => {
+    it("should have the correct number of ids", () => {
+        const geometry = new S2GeometryProvider();
+        const cellId = geometry.lngLatToCellId({ lat: 10, lng: 20 });
+
+        expect(connectedComponent(cellId, 0, geometry).length).toBe(1);
+        expect(connectedComponent(cellId, 1, geometry).length).toBe(3 * 3);
+        expect(connectedComponent(cellId, 2, geometry).length).toBe(5 * 5);
+        expect(connectedComponent(cellId, 3, geometry).length).toBe(7 * 7);
+        expect(connectedComponent(cellId, 6, geometry).length).toBe(13 * 13);
+    });
+
+    it("should have unique ids", () => {
+        const geometry = new S2GeometryProvider();
+        const cellId = geometry.lngLatToCellId({ lat: 20, lng: -20 });
+
+        const cc0 = connectedComponent(cellId, 0, geometry);
+        expect(cc0.length).toBe(new Set(cc0).size);
+
+        const cc1 = connectedComponent(cellId, 1, geometry);
+        expect(cc1.length).toBe(new Set(cc1).size);
+
+        const cc2 = connectedComponent(cellId, 2, geometry);
+        expect(cc2.length).toBe(new Set(cc2).size);
+
+        const cc3 = connectedComponent(cellId, 3, geometry);
+        expect(cc3.length).toBe(new Set(cc3).size);
+
+        const cc6 = connectedComponent(cellId, 6, geometry);
+        expect(cc6.length).toBe(new Set(cc6).size);
+
+    });
+});

--- a/test/graph/Graph.test.ts
+++ b/test/graph/Graph.test.ts
@@ -1030,7 +1030,7 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(true);
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(false);
     });
@@ -1086,7 +1086,7 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(true);
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(false);
     });
@@ -1140,7 +1140,7 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(true);
 
-        graph.uncache([], sequenceId);
+        graph.uncache([], [], sequenceId);
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(true);
     });
@@ -1194,7 +1194,7 @@ describe("Graph.cacheSequenceNodes$", () => {
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(true);
 
-        graph.uncache([fullNode.id]);
+        graph.uncache([fullNode.id], []);
 
         expect(graph.hasSequenceNodes(sequenceId)).toBe(true);
     });
@@ -1273,7 +1273,7 @@ describe("Graph.cacheSequenceNodes$", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(1);
@@ -1355,7 +1355,7 @@ describe("Graph.cacheSequenceNodes$", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([], sequenceId);
+        graph.uncache([], [], sequenceId);
 
         expect(nodeUncacheSpy.calls.count()).toBe(1);
         expect(nodeDisposeSpy.calls.count()).toBe(0);
@@ -2799,7 +2799,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(1);
@@ -2847,7 +2847,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([], fullNode.sequence.id);
+        graph.uncache([], [], fullNode.sequence.id);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(0);
@@ -2895,7 +2895,7 @@ describe("Graph.uncache", () => {
         const node = graph.getNode(fullNode.id);
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeDisposeSpy.calls.count()).toBe(1);
 
@@ -2943,7 +2943,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([fullNode.id]);
+        graph.uncache([fullNode.id], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(0);
@@ -2992,7 +2992,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(0);
@@ -3073,7 +3073,7 @@ describe("Graph.uncache", () => {
 
         graph.hasNode(node2.id);
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeDisposeSpy1.calls.count()).toBe(1);
         expect(nodeDisposeSpy2.calls.count()).toBe(0);
@@ -3141,7 +3141,7 @@ describe("Graph.uncache", () => {
         const node = graph.getNode(fullNode.id);
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(1);
 
@@ -3208,7 +3208,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(0);
@@ -3276,7 +3276,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache");
         nodeUncacheSpy.and.stub();
 
-        graph.uncache([node.id]);
+        graph.uncache([node.id], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
 
@@ -3337,7 +3337,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(0);
@@ -3438,7 +3438,7 @@ describe("Graph.uncache", () => {
 
         graph.hasNode(node2.id);
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy1.calls.count()).toBe(1);
         expect(graph.hasNode(node1.id)).toBe(true);
@@ -3481,7 +3481,7 @@ describe("Graph.uncache", () => {
         const sequenceDisposeSpy = spyOn(sequence, "dispose");
         sequenceDisposeSpy.and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(sequenceDisposeSpy.calls.count()).toBe(1);
 
@@ -3520,7 +3520,7 @@ describe("Graph.uncache", () => {
         const sequenceDisposeSpy = spyOn(sequence, "dispose");
         sequenceDisposeSpy.and.stub();
 
-        graph.uncache([], sequenceId);
+        graph.uncache([], [], sequenceId);
 
         expect(sequenceDisposeSpy.calls.count()).toBe(0);
 
@@ -3560,7 +3560,7 @@ describe("Graph.uncache", () => {
         const sequenceDisposeSpy = spyOn(sequence, "dispose");
         sequenceDisposeSpy.and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(sequenceDisposeSpy.calls.count()).toBe(0);
 
@@ -3623,7 +3623,7 @@ describe("Graph.uncache", () => {
         }
 
         graph.getSequence(sequenceId2);
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(sequenceDisposeSpy1.calls.count()).toBe(1);
         expect(graph.hasSequence(sequence1.id)).toBe(false);
@@ -3690,7 +3690,7 @@ describe("Graph.uncache", () => {
         const nodeDisposeSpy = spyOn(node, "dispose");
         nodeDisposeSpy.and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeDisposeSpy.calls.count()).toBe(1);
 
@@ -3756,7 +3756,7 @@ describe("Graph.uncache", () => {
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
 
-        graph.uncache([], fullNode.sequence.id);
+        graph.uncache([], [], fullNode.sequence.id);
 
         expect(nodeDisposeSpy.calls.count()).toBe(0);
         expect(nodeUncacheSpy.calls.count()).toBe(1);
@@ -3821,7 +3821,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([]);
+        graph.uncache([], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(0);
@@ -3887,7 +3887,7 @@ describe("Graph.uncache", () => {
         const nodeUncacheSpy = spyOn(node, "uncache").and.stub();
         const nodeDisposeSpy = spyOn(node, "dispose").and.stub();
 
-        graph.uncache([node.id]);
+        graph.uncache([node.id], []);
 
         expect(nodeUncacheSpy.calls.count()).toBe(0);
         expect(nodeDisposeSpy.calls.count()).toBe(0);

--- a/test/graph/GraphService.test.ts
+++ b/test/graph/GraphService.test.ts
@@ -1043,12 +1043,14 @@ describe("GraphService.uncache$", () => {
 
         const graphService: GraphService = new GraphService(graph);
 
-        graphService.uncache$(["nKey"], "sKey").subscribe(() => { /*noop*/ });
+        graphService.uncache$(["nKey"], ["cKey"], "sKey").subscribe(() => { /*noop*/ });
 
         expect(uncacheSpy.calls.count()).toBe(1);
-        expect(uncacheSpy.calls.first().args.length).toBe(2);
+        expect(uncacheSpy.calls.first().args.length).toBe(3);
         expect(uncacheSpy.calls.first().args[0].length).toBe(1);
         expect(uncacheSpy.calls.first().args[0][0]).toBe("nKey");
-        expect(uncacheSpy.calls.first().args[1]).toBe("sKey");
+        expect(uncacheSpy.calls.first().args[1].length).toBe(1);
+        expect(uncacheSpy.calls.first().args[1][0]).toBe("cKey");
+        expect(uncacheSpy.calls.first().args[2]).toBe("sKey");
     });
 });

--- a/test/viewer/CacheService.test.ts
+++ b/test/viewer/CacheService.test.ts
@@ -8,7 +8,6 @@ import { ImageHelper } from "../helper/ImageHelper";
 import { Image } from "../../src/graph/Image";
 import { APIWrapper } from "../../src/api/APIWrapper";
 import { FalcorDataProvider } from "../../src/api/falcor/FalcorDataProvider";
-import { CoreImageEnt } from "../../src/api/ents/CoreImageEnt";
 import { Graph } from "../../src/graph/Graph";
 import { GraphMode } from "../../src/graph/GraphMode";
 import { GraphService } from "../../src/graph/GraphService";
@@ -20,33 +19,47 @@ import { CacheService } from "../../src/viewer/CacheService";
 
 describe("CacheService.ctor", () => {
     it("should be defined when constructed", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graphService: GraphService = new GraphService(new Graph(api));
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graphService = new GraphService(new Graph(api));
         const stateService: StateService = new StateService(State.Traversing);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         expect(cacheService).toBeDefined();
     });
 });
 
-describe("CacheService.started", () => {
-    it("should not be started", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graphService: GraphService = new GraphService(new Graph(api));
+describe("CacheService.configure", () => {
+    it("should configure without errors", () => {
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graphService = new GraphService(new Graph(api));
         const stateService: StateService = new StateService(State.Traversing);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
+
+        expect(() => { cacheService.configure(); }).not.toThrow();
+        expect(() => { cacheService.configure({ cellDepth: 5 }); })
+            .not.toThrow();
+    });
+});
+
+describe("CacheService.started", () => {
+    it("should not be started", () => {
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graphService = new GraphService(new Graph(api));
+        const stateService: StateService = new StateService(State.Traversing);
+
+        const cacheService = new CacheService(graphService, stateService, api);
 
         expect(cacheService.started).toBe(false);
     });
 
     it("should be started after calling start", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graphService: GraphService = new GraphService(new Graph(api));
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graphService = new GraphService(new Graph(api));
         const stateService: StateService = new StateService(State.Traversing);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         cacheService.start();
 
@@ -54,11 +67,11 @@ describe("CacheService.started", () => {
     });
 
     it("should not be started after calling stop", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graphService: GraphService = new GraphService(new Graph(api));
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graphService = new GraphService(new Graph(api));
         const stateService: StateService = new StateService(State.Traversing);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         cacheService.start();
         cacheService.stop();
@@ -109,31 +122,31 @@ describe("CacheService.start", () => {
     });
 
     it("should call graph service uncache method", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graph: Graph = new Graph(api);
-        const graphService: GraphService = new GraphService(graph);
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graph = new Graph(api);
+        const graphService = new GraphService(graph);
         graphService.setGraphMode(GraphMode.Spatial);
 
-        const currentStateSubject$: Subject<AnimationFrame> = new Subject<AnimationFrame>();
-        const stateService: TestStateService = new TestStateService(currentStateSubject$);
+        const currentStateSubject$ = new Subject<AnimationFrame>();
+        const stateService = new TestStateService(currentStateSubject$);
 
-        const uncacheSpy: jasmine.Spy = spyOn(graphService, "uncache$");
-        const uncacheSubject: Subject<Graph> = new Subject<Graph>();
+        const uncacheSpy = spyOn(graphService, "uncache$");
+        const uncacheSubject = new Subject<Graph>();
         uncacheSpy.and.returnValue(uncacheSubject);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         cacheService.start();
 
-        const coreImage1: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage1 = helper.createCoreImageEnt();
         coreImage1.id = "image1";
-        const image1: Image = new Image(coreImage1);
+        const image1 = new Image(coreImage1);
 
-        const coreImage2: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage2 = helper.createCoreImageEnt();
         coreImage2.id = "image2";
-        const image2: Image = new Image(coreImage2);
+        const image2 = new Image(coreImage2);
 
-        const state: IAnimationState = createState();
+        const state = createState();
         state.trajectory = [image1, image2];
         state.currentImage = image1;
 
@@ -143,40 +156,41 @@ describe("CacheService.start", () => {
         uncacheSubject.complete();
 
         expect(uncacheSpy.calls.count()).toBe(1);
-        expect(uncacheSpy.calls.first().args.length).toBe(2);
+        expect(uncacheSpy.calls.first().args.length).toBe(3);
         expect(uncacheSpy.calls.first().args[0].length).toBe(2);
         expect(uncacheSpy.calls.first().args[0][0]).toBe(coreImage1.id);
         expect(uncacheSpy.calls.first().args[0][1]).toBe(coreImage2.id);
-        expect(uncacheSpy.calls.first().args[1]).toBeUndefined();
+        expect(uncacheSpy.calls.first().args[1].length).toBe(9);
+        expect(uncacheSpy.calls.first().args[2]).toBeUndefined();
     });
 
     it("should call graph service uncache method with sequence key of last trajectory image", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graph: Graph = new Graph(api);
-        const graphService: GraphService = new GraphService(graph);
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graph = new Graph(api);
+        const graphService = new GraphService(graph);
         graphService.setGraphMode(GraphMode.Sequence);
 
-        const currentStateSubject$: Subject<AnimationFrame> = new Subject<AnimationFrame>();
-        const stateService: TestStateService = new TestStateService(currentStateSubject$);
+        const currentStateSubject$ = new Subject<AnimationFrame>();
+        const stateService = new TestStateService(currentStateSubject$);
 
-        const uncacheSpy: jasmine.Spy = spyOn(graphService, "uncache$");
-        const uncacheSubject: Subject<Graph> = new Subject<Graph>();
+        const uncacheSpy = spyOn(graphService, "uncache$");
+        const uncacheSubject = new Subject<Graph>();
         uncacheSpy.and.returnValue(uncacheSubject);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         cacheService.start();
 
-        const coreImage1: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage1 = helper.createCoreImageEnt();
         coreImage1.id = "image1";
-        const image1: Image = new Image(coreImage1);
+        const image1 = new Image(coreImage1);
 
-        const coreImage2: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage2 = helper.createCoreImageEnt();
         coreImage2.id = "image2";
         coreImage2.sequence.id = "sequence2";
-        const image2: Image = new Image(coreImage2);
+        const image2 = new Image(coreImage2);
 
-        const state: IAnimationState = createState();
+        const state = createState();
         state.trajectory = [image1, image2];
         state.currentImage = image1;
 
@@ -186,42 +200,43 @@ describe("CacheService.start", () => {
         uncacheSubject.complete();
 
         expect(uncacheSpy.calls.count()).toBe(1);
-        expect(uncacheSpy.calls.first().args.length).toBe(2);
+        expect(uncacheSpy.calls.first().args.length).toBe(3);
         expect(uncacheSpy.calls.first().args[0].length).toBe(2);
         expect(uncacheSpy.calls.first().args[0][0]).toBe(coreImage1.id);
         expect(uncacheSpy.calls.first().args[0][1]).toBe(coreImage2.id);
-        expect(uncacheSpy.calls.first().args[1]).toBe(coreImage2.sequence.id);
+        expect(uncacheSpy.calls.first().args[1].length).toBe(9);
+        expect(uncacheSpy.calls.first().args[2]).toBe(coreImage2.sequence.id);
     });
 
     it("should cache current image if switching to sequence graph mode", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graph: Graph = new Graph(api);
-        const graphService: GraphService = new GraphService(graph);
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graph = new Graph(api);
+        const graphService = new GraphService(graph);
 
         spyOn(graphService, "uncache$").and.returnValue(observableOf<void>(null));
 
         graphService.setGraphMode(GraphMode.Spatial);
 
-        const currentStateSubject$: Subject<AnimationFrame> = new Subject<AnimationFrame>();
-        const stateService: TestStateService = new TestStateService(currentStateSubject$);
+        const currentStateSubject$ = new Subject<AnimationFrame>();
+        const stateService = new TestStateService(currentStateSubject$);
 
-        const cacheImageSpy: jasmine.Spy = spyOn(graphService, "cacheImage$");
-        const cacheImageSubject: Subject<Graph> = new Subject<Graph>();
+        const cacheImageSpy = spyOn(graphService, "cacheImage$");
+        const cacheImageSubject = new Subject<Graph>();
         cacheImageSpy.and.returnValue(cacheImageSubject);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         cacheService.start();
 
-        const coreImage1: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage1 = helper.createCoreImageEnt();
         coreImage1.id = "image1";
-        const image1: Image = new Image(coreImage1);
+        const image1 = new Image(coreImage1);
 
-        const coreImage2: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage2 = helper.createCoreImageEnt();
         coreImage2.id = "image2";
-        const image2: Image = new Image(coreImage2);
+        const image2 = new Image(coreImage2);
 
-        const state: IAnimationState = createState();
+        const state = createState();
         state.trajectory = [image1, image2];
         state.currentImage = image1;
 
@@ -237,38 +252,38 @@ describe("CacheService.start", () => {
     });
 
     it("should cache all trajectory images ahead if switching to spatial graph mode", () => {
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graph: Graph = new Graph(api);
-        const graphService: GraphService = new GraphService(graph);
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graph = new Graph(api);
+        const graphService = new GraphService(graph);
 
         spyOn(graphService, "uncache$").and.returnValue(observableOf<void>(null));
 
         graphService.setGraphMode(GraphMode.Sequence);
 
-        const currentStateSubject$: Subject<AnimationFrame> = new Subject<AnimationFrame>();
-        const stateService: TestStateService = new TestStateService(currentStateSubject$);
+        const currentStateSubject$ = new Subject<AnimationFrame>();
+        const stateService = new TestStateService(currentStateSubject$);
 
-        const cacheImageSpy: jasmine.Spy = spyOn(graphService, "cacheImage$");
-        const cacheImageSubject: Subject<Graph> = new Subject<Graph>();
+        const cacheImageSpy = spyOn(graphService, "cacheImage$");
+        const cacheImageSubject = new Subject<Graph>();
         cacheImageSpy.and.returnValue(cacheImageSubject);
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         cacheService.start();
 
-        const coreImage1: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage1 = helper.createCoreImageEnt();
         coreImage1.id = "image1";
-        const image1: Image = new Image(coreImage1);
+        const image1 = new Image(coreImage1);
 
-        const coreImage2: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage2 = helper.createCoreImageEnt();
         coreImage2.id = "image2";
-        const image2: Image = new Image(coreImage2);
+        const image2 = new Image(coreImage2);
 
-        const coreImage3: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage3 = helper.createCoreImageEnt();
         coreImage3.id = "image3";
-        const image3: Image = new Image(coreImage3);
+        const image3 = new Image(coreImage3);
 
-        const state: IAnimationState = createState();
+        const state = createState();
         state.trajectory = [image1, image2, image3];
         state.currentImage = image2;
         state.currentIndex = 1;
@@ -289,40 +304,40 @@ describe("CacheService.start", () => {
     it("should keep the subscription open if caching a image fails", () => {
         spyOn(console, "error").and.stub();
 
-        const api: APIWrapper = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
-        const graph: Graph = new Graph(api);
-        const graphService: GraphService = new GraphService(graph);
+        const api = new APIWrapper(new FalcorDataProvider({ clientToken: "cid" }));
+        const graph = new Graph(api);
+        const graphService = new GraphService(graph);
 
         spyOn(graphService, "uncache$").and.returnValue(observableOf<void>(null));
 
-        const currentStateSubject$: Subject<AnimationFrame> = new Subject<AnimationFrame>();
-        const stateService: TestStateService = new TestStateService(currentStateSubject$);
+        const currentStateSubject$ = new Subject<AnimationFrame>();
+        const stateService = new TestStateService(currentStateSubject$);
 
-        const cacheImageSpy: jasmine.Spy = spyOn(graphService, "cacheImage$");
+        const cacheImageSpy = spyOn(graphService, "cacheImage$");
 
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService = new CacheService(graphService, stateService, api);
 
         cacheService.start();
 
-        const coreImage1: CoreImageEnt = helper.createCoreImageEnt();
+        const coreImage1 = helper.createCoreImageEnt();
         coreImage1.id = "image1";
-        const image1: Image = new Image(coreImage1);
+        const image1 = new Image(coreImage1);
 
-        const state: IAnimationState = createState();
+        const state = createState();
         state.trajectory = [image1];
         state.currentImage = image1;
         state.currentIndex = 0;
 
         currentStateSubject$.next({ fps: 60, id: 0, state: state });
 
-        const cacheImageSubject1: Subject<Graph> = new Subject<Graph>();
+        const cacheImageSubject1 = new Subject<Graph>();
         cacheImageSpy.and.returnValue(cacheImageSubject1);
 
         graphService.setGraphMode(GraphMode.Sequence);
 
         cacheImageSubject1.error(new Error());
 
-        const cacheImageSubject2: Subject<Graph> = new Subject<Graph>();
+        const cacheImageSubject2 = new Subject<Graph>();
         cacheImageSpy.and.returnValue(cacheImageSubject2);
 
         graphService.setGraphMode(GraphMode.Spatial);

--- a/test/viewer/Navigator.test.ts
+++ b/test/viewer/Navigator.test.ts
@@ -64,7 +64,7 @@ describe("Navigator.ctor", () => {
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const navigator: Navigator =
             new Navigator(
@@ -86,7 +86,7 @@ describe("Navigator.moveToKey$", () => {
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const loadingSpy: jasmine.Spy = spyOn(loadingService, "startLoading").and.stub();
 
@@ -153,7 +153,7 @@ describe("Navigator.moveToKey$", () => {
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
         const stopLoadingSpy: jasmine.Spy = spyOn(loadingService, "stopLoading").and.stub();
@@ -190,7 +190,7 @@ describe("Navigator.moveToKey$", () => {
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
         spyOn(loadingService, "stopLoading").and.stub();
@@ -303,7 +303,7 @@ describe("Navigator.moveToKey$", () => {
             const graphService: GraphService = new GraphService(new Graph(api));
             const loadingService: LoadingService = new LoadingService();
             const stateService: StateService = new StateService(State.Traversing);
-            const cacheService: CacheService = new CacheService(graphService, stateService);
+            const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
             spyOn(loadingService, "startLoading").and.stub();
             spyOn(loadingService, "stopLoading").and.stub();
@@ -363,7 +363,7 @@ describe("Navigator.movedToKey$", () => {
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
         spyOn(loadingService, "stopLoading").and.stub();
@@ -433,7 +433,7 @@ describe("Navigator.setFilter$", () => {
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const clearImagesSpy: jasmine.Spy = spyOn(stateService, "clearImages").and.stub();
 
@@ -476,7 +476,7 @@ describe("Navigator.setFilter$", () => {
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const setFilterSpy: jasmine.Spy = spyOn(graphService, "setFilter$");
         setFilterSpy.and.returnValue(new Subject<Graph>());
@@ -509,7 +509,7 @@ describe("Navigator.setFilter$", () => {
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
         const setImagesSpy: jasmine.Spy = spyOn(stateService, "setImages").and.stub();
@@ -574,7 +574,7 @@ describe("Navigator.setFilter$", () => {
 
         const currentStateSubject$: Subject<AnimationFrame> = new Subject<AnimationFrame>();
         const stateService: TestStateService = new TestStateService(currentStateSubject$);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(cacheService, "start").and.stub();
 
@@ -670,7 +670,7 @@ describe("Navigator.setToken$", () => {
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(cacheService, "start").and.stub();
 
@@ -718,7 +718,7 @@ describe("Navigator.setToken$", () => {
 
         const currentStateSubject$: Subject<AnimationFrame> = new Subject<AnimationFrame>();
         const stateService: TestStateService = new TestStateService(currentStateSubject$);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(cacheService, "start").and.stub();
 
@@ -812,7 +812,7 @@ describe("Navigator.setToken$", () => {
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateService(State.Traversing);
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
         spyOn(loadingService, "stopLoading").and.stub();
@@ -847,7 +847,7 @@ describe("Navigator.setToken$", () => {
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
         const stateService: StateService = new StateServiceMockCreator().create();
-        const cacheService: CacheService = new CacheService(graphService, stateService);
+        const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
         spyOn(loadingService, "stopLoading").and.stub();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensure that visible items are rendered immediately on spatial activation.

## Contribution

- Keep cell grid of configurable depth at uncaching so that valid spatially visualized cells are not uncached in graph
- Re-emit all cells to all subscriptions in spatial component
- Refactor cell math to make it reusable and unit test
- Reset spatial scene completely on deactivation

## Test Plan

```
yarn build
yarn test
yarn start
```
