### PR TITLE
Render spherical camera frames

### DIFF
--- a/src/component/spatial/scene/PerspectiveCameraFrame.ts
+++ b/src/component/spatial/scene/PerspectiveCameraFrame.ts
@@ -19,13 +19,12 @@ export class PerspectiveCameraFrame extends CameraFrameBase {
         origin: number[])
         : number[] {
 
-        const depth = size;
         const [originX, originY, originZ] = origin;
 
         const cameraCenter = [0, 0, 0];
         const positions: number[] = [];
         for (const vertex2d of [[0, 0], [1, 0], [1, 1], [0, 1]]) {
-            const corner = transform.unprojectBasic(vertex2d, depth, true);
+            const corner = transform.unprojectBasic(vertex2d, size);
             corner[0] -= originX;
             corner[1] -= originY;
             corner[2] -= originZ;
@@ -48,13 +47,12 @@ export class PerspectiveCameraFrame extends CameraFrameBase {
         vertices2d.push(...this._subsample([0, 0], [1, 0], samples));
         vertices2d.push(...this._subsample([1, 0], [1, 1], samples));
 
-        const depth = size;
         const [originX, originY, originZ] = origin;
         const positions: number[] = [];
         for (const vertex2d of vertices2d) {
             const position =
                 transform.unprojectBasic(
-                    vertex2d, depth, true);
+                    vertex2d, size);
             position[0] -= originX;
             position[1] -= originY;
             position[2] -= originZ;

--- a/src/render/RenderCamera.ts
+++ b/src/render/RenderCamera.ts
@@ -89,7 +89,7 @@ export class RenderCamera {
         this._perspective = new THREE.PerspectiveCamera(
             this._initialFov,
             this._computeAspect(elementWidth, elementHeight),
-            0.16,
+            0.1,
             10000);
         this._perspective.position.copy(this._camera.position);
         this._perspective.up.copy(this._camera.up);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Contribution & Motivation

Render camera frame lines on a sphere instead
of a plane to avoid large star shapes for
short focal lengths.

## Test Plan

```
yarn build
yarn test
yarn start
```
