### PR TITLE
fix: detach custom camera controls correctly

### DIFF
--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -319,8 +319,8 @@ export class Viewer extends EventEmitter implements IViewer {
      * be detached before attaching another custom camera
      * control instance.
      */
-    public detachCustomCameraControls(): void {
-        this._customCameraControls.detach(this);
+    public detachCustomCameraControls(): Promise<ICustomCameraControls> {
+        return this._customCameraControls.detach(this);
     }
 
     public fire(

--- a/test/viewer/CustomCameraControls.test.ts
+++ b/test/viewer/CustomCameraControls.test.ts
@@ -24,7 +24,7 @@ global.WebGL2RenderingContext = <any>jest.fn();
 type WebGLMocks = {
     context: WebGL2RenderingContext;
     renderer: WebGLRenderer;
-}
+};
 
 function createWebGLMocks(): WebGLMocks {
     const renderer = <WebGLRenderer><unknown>new RendererMock();
@@ -682,6 +682,56 @@ describe("CustomRenderer.detach", () => {
 
         (<Subject<State>>navigator.stateService.state$)
             .next(State.Earth);
+    });
+
+    test("should only invoke onDetach once", () => {
+        const navigator = new NavigatorMockCreator().create();
+        const container = new ContainerMockCreator().create();
+        spyOn(Navigator, "Navigator").and.returnValue(navigator);
+        spyOn(Container, "Container").and.returnValue(container);
+
+        const controls = new CustomCameraControls(
+            container,
+            navigator);
+
+        const viewer = <any>{};
+
+        let detachCount = 0;
+        controls.attach(
+            {
+                onActivate: () => {
+                    fail();
+                },
+                onAnimationFrame: () => {
+                    fail();
+                },
+                onAttach: () => {
+                    fail();
+                },
+                onDeactivate: (v) => {
+                    fail();
+                },
+                onDetach: (v) => {
+                    expect(v).toBe(viewer);
+                    detachCount++;
+                },
+                onReference: () => {
+                    fail();
+                },
+                onResize: () => {
+                    fail();
+                },
+            },
+            viewer);
+
+        controls.detach(viewer);
+
+        (<Subject<State>>navigator.stateService.state$)
+            .next(State.Earth);
+        (<Subject<State>>navigator.stateService.state$)
+            .next(State.Traversing);
+
+        expect(detachCount).toBe(1);
     });
 
     test("should invoke onDeactive when detatching if in custom state", done => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensure that `onDetach` is only called once on custom camera control instances when detached.

## Contribution

- Only call `onDetach` once. 
- Unit test.
- Return camera controls in promise when detaching.

## Test Plan

```
yarn test
```