### PR TITLE
feat: public method and event for topocentric reference

### DIFF
--- a/src/external/viewer.ts
+++ b/src/external/viewer.ts
@@ -32,6 +32,7 @@ export { ViewerMouseEvent } from "../viewer/events/ViewerMouseEvent";
 export { ViewerNavigableEvent } from "../viewer/events/ViewerNavigableEvent";
 export { ViewerNavigationEdgeEvent }
     from "../viewer/events/ViewerNavigationEdgeEvent";
+export { ViewerReferenceEvent } from "../viewer/events/ViewerReferenceEvent";
 export { ViewerStateEvent } from "../viewer/events/ViewerStateEvent";
 
 // Viewer options

--- a/src/viewer/Observer.ts
+++ b/src/viewer/Observer.ts
@@ -38,6 +38,7 @@ import { ViewerStateEvent } from "./events/ViewerStateEvent";
 import { ViewerBearingEvent } from "./events/ViewerBearingEvent";
 import { State } from "../state/State";
 import { ViewerLoadEvent } from "./events/ViewerLoadEvent";
+import { ViewerReferenceEvent } from "./events/ViewerReferenceEvent";
 
 type UnprojectionParams = [
     [
@@ -197,7 +198,7 @@ export class Observer {
             .subscribe((image: Image): void => {
                 const type: ViewerEventType = "image";
                 const event: ViewerImageEvent = {
-                    image: image,
+                    image,
                     target: this._viewer,
                     type,
                 };
@@ -235,6 +236,17 @@ export class Observer {
                     };
                     this._viewer.fire(type, event);
                 }));
+
+        subs.push(this._navigator.stateService.reference$
+            .subscribe((reference: LngLatAlt): void => {
+                const type: ViewerEventType = "reference";
+                const event: ViewerReferenceEvent = {
+                    reference,
+                    target: this._viewer,
+                    type,
+                };
+                this._viewer.fire(type, event);
+            }));
 
         subs.push(observableCombineLatest(
             this._navigator.stateService.inMotion$,

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -46,6 +46,7 @@ import { ICustomCameraControls } from "./interfaces/ICustomCameraControls";
 import { CustomCameraControls } from "./CustomCameraControls";
 import { ViewerLoadEvent } from "./events/ViewerLoadEvent";
 import { cameraControlsToState } from "./Modes";
+import { ViewerReferenceEvent } from "./events/ViewerReferenceEvent";
 
 /**
  * @class Viewer
@@ -343,6 +344,10 @@ export class Viewer extends EventEmitter implements IViewer {
         event: ViewerNavigationEdgeEvent)
         : void;
     public fire(
+        type: ViewerReferenceEvent["type"],
+        event: ViewerReferenceEvent)
+        : void;
+    public fire(
         type: ViewerStateEvent["type"],
         event: ViewerStateEvent)
         : void;
@@ -625,6 +630,31 @@ export class Viewer extends EventEmitter implements IViewer {
     }
 
     /**
+     * Get the viewer's current reference position.
+     *
+     * @description The reference position specifies the origin in
+     * the viewer's topocentric coordinate system.
+     *
+     * @returns {Promise<LngLatAlt>} Promise to the reference position.
+     *
+     * @example
+     * ```js
+     * viewer.getReference().then(reference => { console.log(reference); });
+     * ```
+     */
+    public getReference(): Promise<LngLatAlt> {
+        return new Promise<LngLatAlt>(
+            (resolve: (reference: LngLatAlt) => void, reject: (reason: Error) => void): void => {
+                this._navigator.stateService.reference$.pipe(
+                    first())
+                    .subscribe(
+                        (reference) => { resolve(reference); },
+                        (error) => { reject(error); });
+            }
+        );
+    }
+
+    /**
      * Get the image's current zoom level.
      *
      * @returns {Promise<number>} Promise to the viewers's current
@@ -751,6 +781,10 @@ export class Viewer extends EventEmitter implements IViewer {
     public off(
         type: ViewerNavigationEdgeEvent["type"],
         handler: (event: ViewerNavigationEdgeEvent) => void)
+        : void;
+    public off(
+        type: ViewerReferenceEvent["type"],
+        handler: (event: ViewerReferenceEvent) => void)
         : void;
     public off(
         type: ViewerStateEvent["type"],
@@ -1111,6 +1145,27 @@ export class Viewer extends EventEmitter implements IViewer {
     public on(
         type: "pov",
         handler: (event: ViewerStateEvent) => void)
+        : void;
+    /**
+     * Fired when the viewer's reference position changes.
+     *
+     * The reference position specifies the origin in
+     * the viewer's topocentric coordinate system.
+     *
+     * @event reference
+     * @example
+     * ```js
+     * // Initialize the viewer
+     * var viewer = new Viewer({ // viewer options });
+     * // Set an event listener
+     * viewer.on("reference", function(reference) {
+     *   console.log("A reference event has occurred.");
+     * });
+     * ```
+     */
+    public on(
+        type: "reference",
+        handler: (event: ViewerReferenceEvent) => void)
         : void;
     /**
      * Fired when the viewer is removed. After this event is emitted

--- a/src/viewer/events/ViewerEventType.ts
+++ b/src/viewer/events/ViewerEventType.ts
@@ -20,6 +20,7 @@ export type ViewerEventType =
     | "image"
     | "position"
     | "pov"
+    | "reference"
     | "remove"
     | "sequenceedges"
     | "spatialedges";

--- a/src/viewer/events/ViewerReferenceEvent.ts
+++ b/src/viewer/events/ViewerReferenceEvent.ts
@@ -1,0 +1,14 @@
+import { LngLatAlt } from "../../external/api";
+import { ViewerEvent } from "./ViewerEvent";
+
+/**
+ * Interface for viewer reference events.
+ */
+export interface ViewerReferenceEvent extends ViewerEvent {
+    /**
+     * The viewer's current reference.
+     */
+    reference: LngLatAlt;
+
+    type: "reference";
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make it possible to retrieve the topocentric reference for calculations.

## Contribution

- Add `Viewer.getReference` method
- Add `Viewer#reference` event

## Test Plan

```
yarn start
```
