### PR TITLE
Add provider interfaces

### DIFF
--- a/src/api/APIWrapper.ts
+++ b/src/api/APIWrapper.ts
@@ -2,7 +2,6 @@ import {
     Observable,
     Subscriber,
 } from "rxjs";
-import { DataProviderBase } from "./DataProviderBase";
 import { CoreImagesContract } from "./contracts/CoreImagesContract";
 import { ImagesContract } from "./contracts/ImagesContract";
 import { SpatialImagesContract } from "./contracts/SpatialImagesContract";
@@ -10,6 +9,7 @@ import { SequenceContract } from "./contracts/SequenceContract";
 import { ImageTilesRequestContract }
     from "./contracts/ImageTilesRequestContract";
 import { ImageTilesContract } from "./contracts/ImageTilesContract";
+import { IDataProvider } from "./interfaces/IDataProvider";
 
 /**
  * @class API
@@ -17,9 +17,9 @@ import { ImageTilesContract } from "./contracts/ImageTilesContract";
  * @classdesc Provides methods for access to the API.
  */
 export class APIWrapper {
-    constructor(private readonly _data: DataProviderBase) { }
+    constructor(private readonly _data: IDataProvider) { }
 
-    public get data(): DataProviderBase {
+    public get data(): IDataProvider {
         return this._data;
     }
 

--- a/src/api/CellMath.ts
+++ b/src/api/CellMath.ts
@@ -1,9 +1,9 @@
-import { GeometryProvider } from "../../test/helper/ProviderHelper";
+import { IGeometryProvider } from "./interfaces/IGeometryProvider";
 
 export function connectedComponent(
     cellId: string,
     depth: number,
-    geometry: GeometryProvider)
+    geometry: IGeometryProvider)
     : string[] {
 
     const cells = new Set<string>();
@@ -17,7 +17,7 @@ function connectedComponentRecursive(
     current: string[],
     currentDepth: number,
     maxDepth: number,
-    geometry: GeometryProvider)
+    geometry: IGeometryProvider)
     : void {
 
     if (currentDepth >= maxDepth) { return; }

--- a/src/api/DataProviderBase.ts
+++ b/src/api/DataProviderBase.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from "../util/EventEmitter";
 import { ClusterContract }
     from "./contracts/ClusterContract";
 import { MeshContract } from "./contracts/MeshContract";
-import { GeometryProviderBase } from "./GeometryProviderBase";
 import { CoreImagesContract } from "./contracts/CoreImagesContract";
 import { SpatialImagesContract } from "./contracts/SpatialImagesContract";
 import { ImagesContract } from "./contracts/ImagesContract";
@@ -15,6 +14,7 @@ import { ProviderEventType } from "./events/ProviderEventType";
 import { ProviderEvent } from "./events/ProviderEvent";
 import { ProviderCellEvent } from "./events/ProviderCellEvent";
 import { IDataProvider } from "./interfaces/IDataProvider";
+import { IGeometryProvider } from "./interfaces/IGeometryProvider";
 
 /**
  * @class DataProviderBase
@@ -38,19 +38,19 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
     /**
      * Create a new data provider base instance.
      *
-     * @param {GeometryProviderBase} geometry - Geometry
+     * @param {IGeometryProvider} geometry - Geometry
      * provider instance.
      */
-    constructor(protected _geometry: GeometryProviderBase) {
+    constructor(protected _geometry: IGeometryProvider) {
         super();
     }
 
     /**
      * Get geometry property.
      *
-     * @returns {GeometryProviderBase} Geometry provider instance.
+     * @returns {IGeometryProvider} Geometry provider instance.
      */
-    public get geometry(): GeometryProviderBase {
+    public get geometry(): IGeometryProvider {
         return this._geometry;
     }
 

--- a/src/api/GeometryProviderBase.ts
+++ b/src/api/GeometryProviderBase.ts
@@ -3,6 +3,7 @@ import {
     enuToGeodetic,
     geodeticToEnu,
 } from "../geo/GeoCoords";
+import { IGeometryProvider } from "./interfaces/IGeometryProvider";
 import { LngLat } from "./interfaces/LngLat";
 
 /**
@@ -18,7 +19,7 @@ import { LngLat } from "./interfaces/LngLat";
  * }
  * ```
  */
-export abstract class GeometryProviderBase {
+export abstract class GeometryProviderBase implements IGeometryProvider {
     /**
      * Create a new geometry provider base instance.
      */

--- a/src/api/events/ProviderEvent.ts
+++ b/src/api/events/ProviderEvent.ts
@@ -1,4 +1,4 @@
-import { DataProviderBase } from "../DataProviderBase";
+import { IDataProvider } from "../interfaces/IDataProvider";
 import { ProviderEventType } from "./ProviderEventType";
 
 /**
@@ -8,7 +8,7 @@ export interface ProviderEvent {
     /**
      * Data provider target that emitted the event.
      */
-    target: DataProviderBase;
+    target: IDataProvider;
 
     /**
      * Provider event type.

--- a/src/api/interfaces/IDataProvider.ts
+++ b/src/api/interfaces/IDataProvider.ts
@@ -1,58 +1,34 @@
-import { MapillaryError } from "../error/MapillaryError";
-import { EventEmitter } from "../util/EventEmitter";
+import { EventEmitter } from "../../util/EventEmitter";
 import { ClusterContract }
-    from "./contracts/ClusterContract";
-import { MeshContract } from "./contracts/MeshContract";
-import { GeometryProviderBase } from "./GeometryProviderBase";
-import { CoreImagesContract } from "./contracts/CoreImagesContract";
-import { SpatialImagesContract } from "./contracts/SpatialImagesContract";
-import { ImagesContract } from "./contracts/ImagesContract";
-import { SequenceContract } from "./contracts/SequenceContract";
-import { ImageTilesContract } from "./contracts/ImageTilesContract";
+    from "../contracts/ClusterContract";
+import { MeshContract } from "../contracts/MeshContract";
+import { GeometryProviderBase } from "../GeometryProviderBase";
+import { CoreImagesContract } from "../contracts/CoreImagesContract";
+import { SpatialImagesContract } from "../contracts/SpatialImagesContract";
+import { ImagesContract } from "../contracts/ImagesContract";
+import { SequenceContract } from "../contracts/SequenceContract";
+import { ImageTilesContract } from "../contracts/ImageTilesContract";
 import { ImageTilesRequestContract }
-    from "./contracts/ImageTilesRequestContract";
-import { ProviderEventType } from "./events/ProviderEventType";
-import { ProviderEvent } from "./events/ProviderEvent";
-import { ProviderCellEvent } from "./events/ProviderCellEvent";
-import { IDataProvider } from "./interfaces/IDataProvider";
+    from "../contracts/ImageTilesRequestContract";
+import { ProviderEventType } from "../events/ProviderEventType";
+import { ProviderEvent } from "../events/ProviderEvent";
+import { ProviderCellEvent } from "../events/ProviderCellEvent";
 
 /**
- * @class DataProviderBase
+ * @interface IDataProvider
  *
- * @classdesc Base class to extend if implementing a data provider
+ * Interface describing the members of a data provider
  * class.
  *
  * @fires datacreate
- *
- * @example
- * ```js
- * class MyDataProvider extends DataProviderBase {
- *   constructor() {
- *     super(new S2GeometryProvider());
- *   }
- *   ...
- * }
- * ```
  */
-export abstract class DataProviderBase extends EventEmitter implements IDataProvider {
-    /**
-     * Create a new data provider base instance.
-     *
-     * @param {GeometryProviderBase} geometry - Geometry
-     * provider instance.
-     */
-    constructor(protected _geometry: GeometryProviderBase) {
-        super();
-    }
-
+export interface IDataProvider extends EventEmitter {
     /**
      * Get geometry property.
      *
      * @returns {GeometryProviderBase} Geometry provider instance.
      */
-    public get geometry(): GeometryProviderBase {
-        return this._geometry;
-    }
+    geometry: GeometryProviderBase;
 
     /**
      * Fire when data has been created in the data provider
@@ -81,21 +57,19 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * provider.fire(type, event);
      * ```
      */
-    public fire(
+    fire(
         type: "datacreate",
         event: ProviderCellEvent)
         : void;
     /** @ignore */
-    public fire(
+    fire(
         type: ProviderEventType,
         event: ProviderEvent)
         : void;
-    public fire<T>(
+    fire<T>(
         type: ProviderEventType,
         event: T)
-        : void {
-        super.fire(type, event);
-    }
+        : void;
 
     /**
      * Get core images in a geometry cell.
@@ -105,10 +79,8 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * the core images of the requested geometry cell id.
      * @throws Rejects the promise on errors.
      */
-    public getCoreImages(
-        cellId: string): Promise<CoreImagesContract> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
+    getCoreImages(
+        cellId: string): Promise<CoreImagesContract>;
 
     /**
      * Get a cluster reconstruction.
@@ -121,11 +93,9 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * cluster reconstruction.
      * @throws Rejects the promise on errors.
      */
-    public getCluster(
+    getCluster(
         url: string,
-        abort?: Promise<void>): Promise<ClusterContract> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
+        abort?: Promise<void>): Promise<ClusterContract>;
 
     /**
      * Get spatial images.
@@ -136,10 +106,8 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * the spatial images of the requested image ids.
      * @throws Rejects the promise on errors.
      */
-    public getSpatialImages(
-        imageIds: string[]): Promise<SpatialImagesContract> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
+    getSpatialImages(
+        imageIds: string[]): Promise<SpatialImagesContract>;
 
     /**
      * Get complete images.
@@ -150,10 +118,8 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * requested image ids.
      * @throws Rejects the promise on errors.
      */
-    public getImages(
-        imageIds: string[]): Promise<ImagesContract> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
+    getImages(
+        imageIds: string[]): Promise<ImagesContract>;
 
     /**
      * Get an image as an array buffer.
@@ -165,12 +131,9 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * buffer containing the image.
      * @throws Rejects the promise on errors.
      */
-    public getImageBuffer(
+    getImageBuffer(
         url: string,
-        abort?: Promise<void>): Promise<ArrayBuffer> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
-
+        abort?: Promise<void>): Promise<ArrayBuffer>;
     /**
      * Get image tiles urls for a tile level.
      *
@@ -187,10 +150,8 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      *   .then((response) => console.log(response));
      * ```
      */
-    public getImageTiles(
-        tiles: ImageTilesRequestContract): Promise<ImageTilesContract> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
+    getImageTiles(
+        tiles: ImageTilesRequestContract): Promise<ImageTilesContract>;
 
     /**
      * Get a mesh.
@@ -201,11 +162,9 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * @returns {Promise<MeshContract>} Promise to the mesh.
      * @throws Rejects the promise on errors.
      */
-    public getMesh(
+    getMesh(
         url: string,
-        abort?: Promise<void>): Promise<MeshContract> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
+        abort?: Promise<void>): Promise<MeshContract>;
 
     /**
      * Get sequence.
@@ -216,26 +175,22 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * requested image ids.
      * @throws Rejects the promise on errors.
      */
-    public getSequence(
-        sequenceId: string): Promise<SequenceContract> {
-        return Promise.reject(new MapillaryError("Not implemented"));
-    }
+    getSequence(sequenceId: string): Promise<SequenceContract>;
 
-    public off(
+    off(
         type: ProviderCellEvent["type"],
         handler: (event: ProviderCellEvent) => void)
         : void;
     /** @ignore */
-    public off(
+    off(
         type: ProviderEventType,
         handler: (event: ProviderEvent) => void)
         : void;
-    public off<T>(
+    /** @ignore */
+    off<T>(
         type: ProviderEventType,
         handler: (event: T) => void)
-        : void {
-        super.off(type, handler);
-    }
+        : void;
 
     /**
      * Fired when data has been created in the data provider
@@ -255,21 +210,20 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * });
      * ```
      */
-    public on(
+    on(
         type: "datacreate",
         handler: (event: ProviderCellEvent) => void)
         : void;
     /** @ignore */
-    public on(
+    on(
         type: ProviderEventType,
         handler: (event: ProviderEvent) => void)
         : void;
-    public on<T>(
+    /** @ignore */
+    on<T>(
         type: ProviderEventType,
         handler: (event: T) => void)
-        : void {
-        super.on(type, handler);
-    }
+        : void;
 
     /**
      * Set an access token for authenticated API requests of
@@ -278,7 +232,5 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
      * @param {string} [accessToken] accessToken - User access
      * token or client access token.
      */
-    public setAccessToken(accessToken?: string): void {
-        throw new MapillaryError("Not implemented");
-    }
+    setAccessToken(accessToken?: string): void;
 }

--- a/src/api/interfaces/IDataProvider.ts
+++ b/src/api/interfaces/IDataProvider.ts
@@ -2,7 +2,6 @@ import { EventEmitter } from "../../util/EventEmitter";
 import { ClusterContract }
     from "../contracts/ClusterContract";
 import { MeshContract } from "../contracts/MeshContract";
-import { GeometryProviderBase } from "../GeometryProviderBase";
 import { CoreImagesContract } from "../contracts/CoreImagesContract";
 import { SpatialImagesContract } from "../contracts/SpatialImagesContract";
 import { ImagesContract } from "../contracts/ImagesContract";
@@ -13,12 +12,15 @@ import { ImageTilesRequestContract }
 import { ProviderEventType } from "../events/ProviderEventType";
 import { ProviderEvent } from "../events/ProviderEvent";
 import { ProviderCellEvent } from "../events/ProviderCellEvent";
+import { IGeometryProvider } from "./IGeometryProvider";
 
 /**
  * @interface IDataProvider
  *
- * Interface describing the members of a data provider
- * class.
+ * Interface describing data provider members.
+ *
+ * This is a specification for implementers to model: it is
+ * not an exported method or class.
  *
  * @fires datacreate
  */
@@ -26,9 +28,9 @@ export interface IDataProvider extends EventEmitter {
     /**
      * Get geometry property.
      *
-     * @returns {GeometryProviderBase} Geometry provider instance.
+     * @returns {IGeometryProvider} Geometry provider instance.
      */
-    geometry: GeometryProviderBase;
+    geometry: IGeometryProvider;
 
     /**
      * Fire when data has been created in the data provider

--- a/src/api/interfaces/IGeometryProvider.ts
+++ b/src/api/interfaces/IGeometryProvider.ts
@@ -1,0 +1,60 @@
+import { LngLat } from "./LngLat";
+
+/**
+ * @interface IGeometryProvider
+ *
+ * Interface describing geometry provider members.
+ *
+ * This is a specification for implementers to model: it
+ * is not an exported method or class.
+ */
+export interface IGeometryProvider {
+    /**
+     * Convert a geodetic bounding box to the the minimum set
+     * of cell ids containing the bounding box.
+     *
+     * @description The bounding box needs
+     * to be sufficiently small to be contained in an area with the size
+     * of maximally four tiles. Up to nine adjacent tiles may be returned.
+     *
+     * @param {LngLat} sw - South west corner of bounding box.
+     * @param {LngLat} ne - North east corner of bounding box.
+     *
+     * @returns {Array<string>} Array of cell ids.
+     */
+    bboxToCellIds(sw: LngLat, ne: LngLat): string[];
+
+    /**
+     * Get the cell ids of all adjacent cells.
+     *
+     * @description In the case of approximately rectangular cells
+     * this is typically the eight orthogonally and diagonally adjacent
+     * cells.
+     *
+     * @param {string} cellId - Id of cell.
+     * @returns {Array<string>} Array of cell ids. No specific
+     * order is guaranteed.
+     */
+    getAdjacent(cellId: string): string[];
+
+    /**
+     * Get the vertices of a cell.
+     *
+     * @description The vertices form an unclosed
+     * clockwise polygon in the 2D longitude, latitude
+     * space. No assumption on the position of the first
+     * vertex relative to the others can be made.
+     *
+     * @param {string} cellId - Id of cell.
+     * @returns {Array<LngLat>} Unclosed clockwise polygon.
+     */
+    getVertices(cellId: string): LngLat[];
+
+    /**
+     * Convert geodetic coordinates to a cell id.
+     *
+     * @param {LngLat} lngLat - Longitude, latitude to convert.
+     * @returns {string} Cell id for the longitude, latitude.
+     */
+    lngLatToCellId(lngLat: LngLat): string;
+}

--- a/src/api/provider/GraphDataProvider.ts
+++ b/src/api/provider/GraphDataProvider.ts
@@ -21,7 +21,7 @@ import { IDEnt } from '../ents/IDEnt';
 import { ImageEnt } from '../ents/ImageEnt';
 import { ImageTileEnt } from '../ents/ImageTileEnt';
 import { SpatialImageEnt } from '../ents/SpatialImageEnt';
-import { GeometryProviderBase } from '../GeometryProviderBase';
+import { IGeometryProvider } from '../interfaces/IGeometryProvider';
 import { S2GeometryProvider } from '../S2GeometryProvider';
 import {
     GraphClusterContract,
@@ -48,7 +48,7 @@ export class GraphDataProvider extends DataProviderBase {
 
     constructor(
         options?: GraphDataProviderOptions,
-        geometry?: GeometryProviderBase,
+        geometry?: IGeometryProvider,
         converter?: GraphConverter,
         queryCreator?: GraphQueryCreator) {
 

--- a/src/component/spatial/SpatialCache.ts
+++ b/src/component/spatial/SpatialCache.ts
@@ -16,8 +16,8 @@ import {
     tap,
 } from "rxjs/operators";
 
-import { DataProviderBase } from "../../api/DataProviderBase";
 import { ClusterContract } from "../../api/contracts/ClusterContract";
+import { IDataProvider } from "../../api/interfaces/IDataProvider";
 import { CancelMapillaryError } from "../../error/CancelMapillaryError";
 import { GraphService } from "../../graph/GraphService";
 import { Image } from "../../graph/Image";
@@ -25,23 +25,23 @@ import { Image } from "../../graph/Image";
 type ClusterData = {
     key: string;
     url: string;
-}
+};
 
 export class SpatialCache {
     private _graphService: GraphService;
-    private _data: DataProviderBase;
+    private _data: IDataProvider;
 
-    private _cacheRequests: { [cellId: string]: Function[] };
-    private _cells: { [cellId: string]: Image[] };
+    private _cacheRequests: { [cellId: string]: Function[]; };
+    private _cells: { [cellId: string]: Image[]; };
 
-    private _clusters: { [key: string]: ClusterContract };
-    private _clusterCells: { [key: string]: string[] };
-    private _cellClusters: { [cellId: string]: ClusterData[] };
+    private _clusters: { [key: string]: ClusterContract; };
+    private _clusterCells: { [key: string]: string[]; };
+    private _cellClusters: { [cellId: string]: ClusterData[]; };
 
-    private _cachingClusters$: { [cellId: string]: Observable<ClusterContract> };
-    private _cachingCells$: { [cellId: string]: Observable<Image[]> };
+    private _cachingClusters$: { [cellId: string]: Observable<ClusterContract>; };
+    private _cachingCells$: { [cellId: string]: Observable<Image[]>; };
 
-    constructor(graphService: GraphService, provider: DataProviderBase) {
+    constructor(graphService: GraphService, provider: IDataProvider) {
         this._graphService = graphService;
         this._data = provider;
 
@@ -357,7 +357,7 @@ export class SpatialCache {
                     if (this._clusterCells[reconstruction.id].indexOf(cellId) === -1) {
                         this._clusterCells[reconstruction.id].push(cellId);
                     }
-                }))
+                }));
     }
 
     private _getCluster(id: string): ClusterContract {

--- a/src/external/api.ts
+++ b/src/external/api.ts
@@ -25,6 +25,7 @@ export { GraphDataProvider } from "../api/provider/GraphDataProvider";
 export { GraphDataProviderOptions }
     from "../api/provider/GraphDataProviderOptions";
 export { IDataProvider } from "../api/interfaces/IDataProvider";
+export { IGeometryProvider } from "../api/interfaces/IGeometryProvider";
 
 export { S2GeometryProvider } from "../api/S2GeometryProvider";
 

--- a/src/external/api.ts
+++ b/src/external/api.ts
@@ -24,6 +24,8 @@ export { GeometryProviderBase } from "../api/GeometryProviderBase";
 export { GraphDataProvider } from "../api/provider/GraphDataProvider";
 export { GraphDataProviderOptions }
     from "../api/provider/GraphDataProviderOptions";
+export { IDataProvider } from "../api/interfaces/IDataProvider";
+
 export { S2GeometryProvider } from "../api/S2GeometryProvider";
 
 // Event

--- a/src/graph/ImageCache.ts
+++ b/src/graph/ImageCache.ts
@@ -21,7 +21,7 @@ import { NavigationEdge } from "./edge/interfaces/NavigationEdge";
 import { NavigationEdgeStatus } from "./interfaces/NavigationEdgeStatus";
 
 import { MeshContract } from "../api/contracts/MeshContract";
-import { DataProviderBase } from "../api/DataProviderBase";
+import { IDataProvider } from "../api/interfaces/IDataProvider";
 import { SpatialImageEnt } from "../api/ents/SpatialImageEnt";
 
 /**
@@ -32,7 +32,7 @@ import { SpatialImageEnt } from "../api/ents/SpatialImageEnt";
 export class ImageCache {
     private _disposed: boolean;
 
-    private _provider: DataProviderBase;
+    private _provider: IDataProvider;
 
     private _image: HTMLImageElement;
     private _mesh: MeshContract;
@@ -58,7 +58,7 @@ export class ImageCache {
     /**
      * Create a new image cache instance.
      */
-    constructor(provider: DataProviderBase) {
+    constructor(provider: IDataProvider) {
         this._disposed = false;
 
         this._provider = provider;

--- a/src/viewer/Navigator.ts
+++ b/src/viewer/Navigator.ts
@@ -24,7 +24,6 @@ import { PlayService } from "./PlayService";
 import { ViewerOptions } from "./options/ViewerOptions";
 
 import { APIWrapper } from "../api/APIWrapper";
-import { DataProviderBase } from "../api/DataProviderBase";
 import { CancelMapillaryError } from "../error/CancelMapillaryError";
 import { FilterExpression } from "../graph/FilterExpression";
 import { Graph } from "../graph/Graph";
@@ -69,11 +68,7 @@ export class Navigator {
         if (api) {
             this._api = api;
         } else if (options.dataProvider) {
-            if (options.dataProvider instanceof DataProviderBase) {
-                this._api = new APIWrapper(options.dataProvider);
-            } else {
-                throw new Error("Incorrect type: 'dataProvider' must extend the DataProviderBase class.");
-            }
+            this._api = new APIWrapper(options.dataProvider);
         } else {
             this._api = new APIWrapper(new GraphDataProvider({
                 accessToken: options.accessToken,

--- a/src/viewer/options/ViewerOptions.ts
+++ b/src/viewer/options/ViewerOptions.ts
@@ -1,7 +1,7 @@
 import { ComponentOptions } from "./ComponentOptions";
 import { UrlOptions } from "./UrlOptions";
 
-import { DataProviderBase } from "../../api/DataProviderBase";
+import { IDataProvider } from "../../api/interfaces/IDataProvider";
 import { RenderMode } from "../../render/RenderMode";
 import { TransitionMode } from "../../state/TransitionMode";
 import { CameraControls } from "../enums/CameraControls";
@@ -61,12 +61,14 @@ export interface ViewerOptions {
      * default MapillaryJS data provider and take responsibility
      * for all IO handling.
      *
-     * The data provider takes precedance over the {@link }
+     * The data provider takes precedence over the {@link ViewerOptions.accessToken} property.
      *
-     * A data provider instance must extend
-     * the data provider base class.
+     * A data provider instance must implement all members
+     * specified in the {@link IDataProvider} interface. This can
+     * be done by extending the {@link DataProviderBase} class or
+     * implementing the interface directly.
      */
-    dataProvider?: DataProviderBase;
+    dataProvider?: IDataProvider;
 
     /**
      * Optional `image-id` to start from. The id


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Do not require providers to extend base classes. This resolves webpack/babel build issues for applications transpiled to ES6 not calling new on provider base classes.

## Contribution

- Add data provider interface
- Add geometry provider interface

## Test Plan

```
yarn start
```
