### PR TITLE
Point visualization modes

### DIFF
--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -2336,6 +2336,12 @@ declare var OriginalPositionMode: {|
   +Flat: 2, // 2
 |};
 
+declare var PointVisualizationMode: {|
+  +Hidden: 0, // 0
+  +Original: 1, // 1
+  +Cluster: 2, // 2
+|};
+
 /**
  * Interface for configuration of spatial component.
  * @interface
@@ -2349,7 +2355,7 @@ declare var OriginalPositionMode: {|
  *             cellsVisible: true,
  *             originalPositionMode: OriginalPositionMode.Altitude,
  *             pointSize: 0.5,
- *             pointsVisible: false,
+ *             pointVisualizationMode: PointVisualizationMode.Hidden,
  *         },
  *     },
  *     ...
@@ -2401,9 +2407,17 @@ export type SpatialConfiguration = {
 
   /**
    * Specify if the points should be visible or not.
+   * @deprecated `pointsVisible` will be removed in
+   * v5.x. Use {@link pointVisualizationMode} instead.
    * @default true
    */
   pointsVisible?: boolean,
+
+  /**
+   * Specify how point clouds should be visualized.
+   * @default PointVisualizationMode.Original
+   */
+  pointVisualizationMode?: $Values<typeof PointVisualizationMode>,
   ...
 } & ComponentConfiguration;
 

--- a/doc/src/js/examples/component-spatial.js
+++ b/doc/src/js/examples/component-spatial.js
@@ -11,6 +11,7 @@ import {
   CameraControls,
   CameraVisualizationMode,
   OriginalPositionMode,
+  PointVisualizationMode,
   Viewer,
 } from '../../mapillary-js/dist/mapillary.module';
 
@@ -39,7 +40,7 @@ export function init(opts) {
       cellGridDepth: 1,
       originalPositionMode: OriginalPositionMode.Hidden,
       pointSize: 0.1,
-      pointsVisible: true,
+      pointVisualizationMode: PointVisualizationMode.Original,
       cellsVisible: false,
     },
   };
@@ -59,7 +60,9 @@ export function init(opts) {
     CameraVisualizationMode[config.cameraVisualizationMode];
   config.originalPositionMode =
     OriginalPositionMode[config.originalPositionMode];
-  config.cameraControls = CameraControls.Street;
+  config.pointVisualizationMode =
+    PointVisualizationMode[config.pointVisualizationMode];
+  config.cameraControls = CameraControls[CameraControls.Street];
   config.image = true;
 
   const configure = (name, value) => {
@@ -115,9 +118,15 @@ export function init(opts) {
       open: true,
     });
     folder.add(
-      new BooleanController(config, 'pointsVisible')
-        .setName('Visible')
-        .onChange(handleConfig('pointsVisible')),
+      new OptionController(config, 'pointVisualizationMode', [
+        PointVisualizationMode[PointVisualizationMode.Original],
+        PointVisualizationMode[PointVisualizationMode.Cluster],
+        PointVisualizationMode[PointVisualizationMode.Hidden],
+      ])
+        .setName('Mode')
+        .onChange((mode) =>
+          configure('pointVisualizationMode', PointVisualizationMode[mode]),
+        ),
     );
     folder.add(
       new NumberController(config, 'pointSize', {min: 0, max: 1})

--- a/examples/debug/spatial.html
+++ b/examples/debug/spatial.html
@@ -34,6 +34,7 @@
                 CameraControls,
                 CameraVisualizationMode,
                 OriginalPositionMode,
+                PointVisualizationMode,
                 Viewer,
             } from "/dist/mapillary.module.js";
             import { accessToken } from "/doc-src/.access-token/token.js";
@@ -115,6 +116,22 @@
                 };
             })();
 
+            const rotatePvm = (function () {
+                const hidden = PointVisualizationMode.Hidden;
+                const original = PointVisualizationMode.Original;
+                const cluster = PointVisualizationMode.Cluster;
+                const pvmRotation = {};
+                pvmRotation[hidden] = original;
+                pvmRotation[original] = cluster;
+                pvmRotation[cluster] = hidden;
+
+                return function () {
+                    s.pointVisualizationMode =
+                        pvmRotation[s.pointVisualizationMode];
+                    configure("pointVisualizationMode");
+                };
+            })();
+
             const setFilter = (function () {
                 let filterIndex = 0;
                 const filters = [
@@ -144,9 +161,6 @@
 
                 let name = undefined;
                 switch (e.key) {
-                    case "p":
-                        name = "pointsVisible";
-                        break;
                     case "t":
                         name = "cellsVisible";
                         break;
@@ -164,6 +178,9 @@
                         break;
                     case "r":
                         rotateCc();
+                        break;
+                    case "p":
+                        rotatePvm();
                         break;
                     case "q":
                         changeSize("pointSize", 0.9);

--- a/src/component/interfaces/SpatialConfiguration.ts
+++ b/src/component/interfaces/SpatialConfiguration.ts
@@ -1,6 +1,7 @@
 import { ComponentConfiguration } from "./ComponentConfiguration";
 import { CameraVisualizationMode } from "../spatial/enums/CameraVisualizationMode";
 import { OriginalPositionMode } from "../spatial/enums/OriginalPositionMode";
+import { PointVisualizationMode } from "../spatial/enums/PointVisualizationMode";
 
 /**
  * Interface for configuration of spatial component.
@@ -17,7 +18,7 @@ import { OriginalPositionMode } from "../spatial/enums/OriginalPositionMode";
  *             cellsVisible: true,
  *             originalPositionMode: OriginalPositionMode.Altitude,
  *             pointSize: 0.5,
- *             pointsVisible: false,
+ *             pointVisualizationMode: PointVisualizationMode.Hidden,
  *         },
  *     },
  *     ...
@@ -77,7 +78,17 @@ export interface SpatialConfiguration extends ComponentConfiguration {
     /**
      * Specify if the points should be visible or not.
      *
+     * @deprecated `pointsVisible` will be removed in
+     * v5.x. Use {@link pointVisualizationMode} instead.
+     *
      * @default true
      */
     pointsVisible?: boolean;
+
+    /**
+     * Specify how point clouds should be visualized.
+     *
+     * @default PointVisualizationMode.Original
+     */
+    pointVisualizationMode?: PointVisualizationMode;
 }

--- a/src/component/spatial/SpatialComponent.ts
+++ b/src/component/spatial/SpatialComponent.ts
@@ -55,13 +55,14 @@ import { ComponentName } from "../ComponentName";
 import { isModeVisible, isOverviewState } from "./Modes";
 import { State } from "../../state/State";
 import { connectedComponent } from "../../api/CellMath";
+import { PointVisualizationMode } from "./enums/PointVisualizationMode";
 
 type IntersectEvent = MouseEvent | FocusEvent;
 
 type Cell = {
     id: string;
     images: Image[];
-}
+};
 
 type AdjancentParams = [boolean, boolean, number, number, Image];
 
@@ -143,7 +144,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
     }
 
     protected _activate(): void {
-        this._navigator.cacheService.configure({ cellDepth: 3 })
+        this._navigator.cacheService.configure({ cellDepth: 3 });
 
         const subs = this._subscriptions;
 
@@ -226,7 +227,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
                     if (o1 !== o2) {
                         return false;
                     }
-                    const isd = i1.id === i2.id && s1 === s2 && d1 === d2
+                    const isd = i1.id === i2.id && s1 === s2 && d1 === d2;
                     if (o1) {
                         return isd;
                     }
@@ -334,14 +335,18 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
                 (c: SpatialConfiguration): SpatialConfiguration => {
                     c.cameraSize = this._spatial.clamp(c.cameraSize, 0.01, 1);
                     c.pointSize = this._spatial.clamp(c.pointSize, 0.01, 1);
+                    const pointVisualizationMode =
+                        c.pointsVisible ?
+                            c.pointVisualizationMode ?? PointVisualizationMode.Original :
+                            PointVisualizationMode.Hidden;
                     return {
                         cameraSize: c.cameraSize,
                         cameraVisualizationMode: c.cameraVisualizationMode,
                         cellsVisible: c.cellsVisible,
                         originalPositionMode: c.originalPositionMode,
                         pointSize: c.pointSize,
-                        pointsVisible: c.pointsVisible,
-                    }
+                        pointVisualizationMode,
+                    };
                 }),
             distinctUntilChanged(
                 (c1: SpatialConfiguration, c2: SpatialConfiguration)
@@ -351,16 +356,17 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
                         c1.cellsVisible === c2.cellsVisible &&
                         c1.originalPositionMode === c2.originalPositionMode &&
                         c1.pointSize === c2.pointSize &&
-                        c1.pointsVisible === c2.pointsVisible;
+                        c1.pointVisualizationMode === c2.pointVisualizationMode;
                 }))
             .subscribe(
                 (c: SpatialConfiguration): void => {
                     this._scene.setCameraSize(c.cameraSize);
-                    this._scene.setPointSize(c.pointSize);
-                    this._scene.setPointVisibility(c.pointsVisible);
-                    this._scene.setCellVisibility(c.cellsVisible);
                     const cvm = c.cameraVisualizationMode;
                     this._scene.setCameraVisualizationMode(cvm);
+                    this._scene.setCellVisibility(c.cellsVisible);
+                    this._scene.setPointSize(c.pointSize);
+                    const pvm = c.pointVisualizationMode;
+                    this._scene.setPointVisualizationMode(pvm);
                     const opm = c.originalPositionMode;
                     this._scene.setPositionMode(opm);
                 }));
@@ -421,7 +427,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
                             size: c.cameraSize,
                             visible: isModeVisible(c.cameraVisualizationMode),
                             state,
-                        }
+                        };
                     }),
                 distinctUntilChanged(
                     (c1: IntersectConfiguration, c2: IntersectConfiguration): boolean => {
@@ -523,7 +529,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
                         );
                     }),
                 publish<[Cell, LngLatAlt]>(),
-                refCount())
+                refCount());
 
         subs.push(updatedCell$
             .subscribe(
@@ -586,6 +592,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
             originalPositionMode: OriginalPositionMode.Hidden,
             pointSize: 0.1,
             pointsVisible: true,
+            pointVisualizationMode: PointVisualizationMode.Original,
             cellsVisible: false,
         };
     }

--- a/src/component/spatial/enums/PointVisualizationMode.ts
+++ b/src/component/spatial/enums/PointVisualizationMode.ts
@@ -1,0 +1,17 @@
+export enum PointVisualizationMode {
+    /**
+     * Points are hidden.
+     */
+    Hidden,
+
+    /**
+     * Visualize points with original colors.
+     */
+    Original,
+
+    /**
+     * Paint all points belonging to a specific
+     * cluster with the same random color.
+     */
+    Cluster,
+}

--- a/src/component/spatial/scene/ClusterPoints.ts
+++ b/src/component/spatial/scene/ClusterPoints.ts
@@ -1,5 +1,6 @@
 import {
     BufferAttribute,
+    Color,
     Points,
     PointsMaterial,
 } from "three";
@@ -7,6 +8,7 @@ import { ClusterContract } from "../../../api/contracts/ClusterContract";
 
 export interface ClusterPointsParameters {
     cluster: ClusterContract;
+    color: string;
     originalSize: number;
     scale: number;
     translation: number[];
@@ -21,14 +23,12 @@ export class ClusterPoints extends Points {
         super();
 
         this._originalSize = parameters.originalSize;
-        const cluster = parameters.cluster;
-        const scale = parameters.scale;
-        const translation = parameters.translation;
+
+        const { cluster, color, scale, translation } = parameters;
 
         this._makeAttributes(cluster);
         this.material.size = scale * this._originalSize;
-        this.material.vertexColors = true;
-        this.material.needsUpdate = true;
+        this.setColor(color);
 
         this.matrixAutoUpdate = false;
         this.position.fromArray(translation);
@@ -39,6 +39,12 @@ export class ClusterPoints extends Points {
     public dispose(): void {
         this.geometry.dispose();
         this.material.dispose();
+    }
+
+    public setColor(color?: string): void {
+        this.material.vertexColors = color == null;
+        this.material.color = new Color(color);
+        this.material.needsUpdate = true;
     }
 
     public resize(scale: number): void {
@@ -56,8 +62,8 @@ export class ClusterPoints extends Points {
                 continue;
             }
 
-            const point = points[pointId]
-            positions.push(...point.coordinates)
+            const point = points[pointId];
+            positions.push(...point.coordinates);
 
             const color = point.color;
             colors.push(color[0]);

--- a/src/external/component.ts
+++ b/src/external/component.ts
@@ -94,6 +94,8 @@ export { CameraVisualizationMode }
     from "../component/spatial/enums/CameraVisualizationMode";
 export { OriginalPositionMode }
     from "../component/spatial/enums/OriginalPositionMode";
+export { PointVisualizationMode }
+    from "../component/spatial/enums/PointVisualizationMode";
 export { SpatialComponent }
     from "../component/spatial/SpatialComponent";
 export { SpatialConfiguration }


### PR DESCRIPTION
Add point visualization mode configuration setting.
Add mode to paint colors in the same cluster with
a single random color.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Simplify visual inspection of point clouds.

## Contribution

- Add point visualization modes as a configuration setting: Hidden, Original, Cluster

## Test Plan

```
yarn build
yarn start
yarn test
yarn --cwd doc start
```
