### PR TITLE
Guard against bleeding css line height values

### DIFF
--- a/styles/attribution.css
+++ b/styles/attribution.css
@@ -6,6 +6,7 @@
     bottom: 0;
     right: 0;
     height: 16px;
+    line-height: initial;
     z-index: 10;
     font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
         "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensure that attribution component is rendered correctly when line height is set globally in parent app.
