### PR TITLE
Improve flow declarations for event emitter and viewer

### DIFF
--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -3212,7 +3212,7 @@ export interface IViewer {
   setCameraControls(controls: $Values<typeof CameraControls>): void;
   setCenter(center: number[]): void;
   setFieldOfView(fov: number): void;
-  setFilter(filter: FilterExpression): Promise<void>;
+  setFilter(filter?: FilterExpression): Promise<void>;
   setRenderMode(renderMode: $Values<typeof RenderMode>): void;
   setTransitionMode(transitionMode: $Values<typeof TransitionMode>): void;
   setAccessToken(accessToken?: string): Promise<void>;
@@ -3980,7 +3980,8 @@ declare class Viewer implements IEventEmitter, IViewer {
    * Set the filter selecting images to use when calculating
    * the spatial edges.
    * @description [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]
-   * @param {FilterExpression} filter - The filter expression.
+   * @param {FilterExpression} [filter] - The filter expression.
+   * Applied filter is cleared if omitted.
    * @returns {Promise<void>} Promise that resolves after filter is applied.
    * @example ```js
    * // Examples
@@ -3989,7 +3990,7 @@ declare class Viewer implements IEventEmitter, IViewer {
    * viewer.setFilter(["in", "sequenceId", "<sequence-id-1>", "<sequence-id-2>"]);
    * ```
    */
-  setFilter(filter: FilterExpression): Promise<void>;
+  setFilter(filter?: FilterExpression): Promise<void>;
 
   /**
  * Set the viewer's render mode.

--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -633,7 +633,7 @@ export interface IGeometryProvider {
  * not an exported method or class.
  * @fires datacreate
  */
-export interface IDataProvider {
+export interface IDataProvider extends IEventEmitter {
   /**
    * Get geometry property.
    * @returns {IGeometryProvider} Geometry provider instance.
@@ -8037,6 +8037,7 @@ declare export {
   PointGeometry,
   PointerComponent,
   PointsGeometry,
+  PointVisualizationMode,
   PolygonGeometry,
   Popup,
   PopupComponent,

--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -173,8 +173,8 @@ declare function readMeshPbf(buffer: ArrayBuffer): MeshContract;
  */
 export interface IEventEmitter {
   fire<T>(type: string, event: T): void;
-  off<T>(type: string, handler: (event: T) => void): void;
-  on<T>(type: string, handler: (event: T) => void): void;
+  off<T>(type: string, handler: (event: T) => mixed): void;
+  on<T>(type: string, handler: (event: T) => mixed): void;
 }
 
 declare class EventEmitter implements IEventEmitter {
@@ -184,19 +184,19 @@ declare class EventEmitter implements IEventEmitter {
    * Subscribe to an event by its name.
    * @param {string} type - The name of the event
    * to subscribe to.
-   * @param {(event: T) => void} handler - The
+   * @param {(event: T) => mixed} handler - The
    * handler called when the event occurs.
    */
-  on<T>(type: string, handler: (event: T) => void): void;
+  on<T>(type: string, handler: (event: T) => mixed): void;
 
   /**
    * Unsubscribe from an event by its name.
    * @param {string} type - The name of the event
    * to unsubscribe from.
-   * @param {(event: T) => void} handler - The
+   * @param {(event: T) => mixed} handler - The
    * handler to remove.
    */
-  off<T>(type: string, handler: (event: T) => void): void;
+  off<T>(type: string, handler: (event: T) => mixed): void;
 
   /**
    * @ignore
@@ -884,9 +884,9 @@ declare class DataProviderBase implements IDataProvider, IEventEmitter {
    */
   getSequence(sequenceId: string): Promise<SequenceContract>;
 
-  off<T>(type: string, handler: (event: T) => void): void;
+  off<T>(type: string, handler: (event: T) => mixed): void;
 
-  on<T>(type: string, handler: (event: T) => void): void;
+  on<T>(type: string, handler: (event: T) => mixed): void;
 
   /**
    * Set an access token for authenticated API requests of
@@ -3202,8 +3202,8 @@ export interface IViewer {
   hasCustomRenderer(rendererId: string): boolean;
   moveDir(direction: $Values<typeof NavigationDirection>): Promise<Image>;
   moveTo(imageId: string): Promise<Image>;
-  off<T>(type: ViewerEventType, handler: (event: T) => void): void;
-  on<T>(type: ViewerEventType, handler: (event: T) => void): void;
+  off<T>(type: ViewerEventType, handler: (event: T) => mixed): void;
+  on<T>(type: ViewerEventType, handler: (event: T) => mixed): void;
   project(lngLat: LngLat): Promise<number[]>;
   projectFromBasic(basicPoint: number[]): Promise<number[]>;
   remove(): void;
@@ -4088,8 +4088,8 @@ declare class Viewer implements IEventEmitter, IViewer {
   unprojectToBasic(pixelPoint: number[]): Promise<number[]>;
 
   fire<T>(type: string, event: T): void;
-  off<T>(type: string, handler: (event: T) => void): void;
-  on<T>(type: string, handler: (event: T) => void): void;
+  off<T>(type: string, handler: (event: T) => mixed): void;
+  on<T>(type: string, handler: (event: T) => mixed): void;
 }
 /**
  * @class MapillaryError
@@ -5269,12 +5269,12 @@ declare class Component<TConfiguration: ComponentConfiguration>
   /**
    * @inheritdoc
    */
-  off<T>(type: string, handler: (event: T) => void): void;
+  off<T>(type: string, handler: (event: T) => mixed): void;
 
   /**
    * @inheritdoc
    */
-  on<T>(type: string, handler: (event: T) => void): void;
+  on<T>(type: string, handler: (event: T) => mixed): void;
 
   /**
    * Detect the viewer's new width and height and resize the component's

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -1497,7 +1497,8 @@ export class Viewer extends EventEmitter implements IViewer {
      * documentation for a full list of properties that can be used
      * in a filter) are shown the the example code.
      *
-     * @param {FilterExpression} filter - The filter expression.
+     * @param {FilterExpression} [filter] - The filter expression.
+     * Applied filter is cleared if omitted.
      * @returns {Promise<void>} Promise that resolves after filter is applied.
      *
      * @example
@@ -1508,7 +1509,7 @@ export class Viewer extends EventEmitter implements IViewer {
      * viewer.setFilter(["in", "sequenceId", "<sequence-id-1>", "<sequence-id-2>"]);
      * ```
      */
-    public setFilter(filter: FilterExpression): Promise<void> {
+    public setFilter(filter?: FilterExpression): Promise<void> {
         return new Promise<void>(
             (resolve: (value: void) => void, reject: (reason: Error) => void): void => {
                 this._navigator.setFilter$(filter)

--- a/src/viewer/interfaces/IViewer.ts
+++ b/src/viewer/interfaces/IViewer.ts
@@ -60,7 +60,7 @@ export interface IViewer {
     setCameraControls(controls: CameraControls): void;
     setCenter(center: number[]): void;
     setFieldOfView(fov: number): void;
-    setFilter(filter: FilterExpression): Promise<void>;
+    setFilter(filter?: FilterExpression): Promise<void>;
     setRenderMode(renderMode: RenderMode): void;
     setTransitionMode(transitionMode: TransitionMode): void;
     setAccessToken(accessToken?: string): Promise<void>;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Expose correctly typed flow declarations.

## Contribution

- Correct `viewer.setFilter` declaration. Make it explicit in the method declaration that it can be cleared by omitting the filter param.
- Export point visualization mode.
- Set event handler return values to mixed to be able to attach any event handler without flow errors.

(If this PR adds or changes functionality, describe it here.)

## Test Plan

```
yarn build-flow
yarn build
yarn test
```
