### PR TITLE
Add viewer method to check if camera controls are attached

### DIFF
--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -3199,6 +3199,7 @@ export interface IViewer {
   getPosition(): Promise<LngLat>;
   getReference(): Promise<LngLatAlt>;
   getZoom(): Promise<number>;
+  hasCustomCameraControls(controls: ICustomCameraControls): boolean;
   hasCustomRenderer(rendererId: string): boolean;
   moveDir(direction: $Values<typeof NavigationDirection>): Promise<Image>;
   moveTo(imageId: string): Promise<Image>;
@@ -3805,6 +3806,15 @@ declare class Viewer implements IEventEmitter, IViewer {
    * ```
    */
   getZoom(): Promise<number>;
+
+  /**
+   * Check if a controls instance is the camera controls that are
+   * currently attached to the viewer.
+   * @param {ICustomCameraControls} controls - Camera controls instance.
+   * @returns {boolean} Value indicating whether the controls instance
+   * is currently attached.
+   */
+  hasCustomCameraControls(controls: ICustomCameraControls): boolean;
 
   /**
    * Check if a custom renderer has been added to the viewer's

--- a/src/viewer/CustomCameraControls.ts
+++ b/src/viewer/CustomCameraControls.ts
@@ -39,6 +39,8 @@ export class CustomCameraControls {
             throw new MapillaryError('Custom camera controls already attached');
         }
 
+        this._controls = controls;
+
         const attach$ = new Subject<void>();
         const active$ = attach$
             .pipe(
@@ -149,13 +151,6 @@ export class CustomCameraControls {
                         attach$.next();
                         attach$.complete();
                     }));
-
-
-        this._controls = controls;
-    }
-
-    public dispose(viewer: IViewer): void {
-        this.detach(viewer);
     }
 
     public detach(viewer: IViewer): Promise<ICustomCameraControls> {
@@ -181,8 +176,14 @@ export class CustomCameraControls {
                     resolve(controls);
                 });
         });
+    }
 
+    public dispose(viewer: IViewer): void {
+        this.detach(viewer);
+    }
 
+    public has(controls: ICustomCameraControls): boolean {
+        return !!this._controls && controls === this._controls;
     }
 
     private _updateProjectionMatrix(projectionMatrix: number[]): void {

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -694,6 +694,17 @@ export class Viewer extends EventEmitter implements IViewer {
             });
     }
 
+    /**
+     * Check if a controls instance is the camera controls that are
+     * currently attached to the viewer.
+     *
+     * @param {ICustomCameraControls} controls - Camera controls instance.
+     * @returns {boolean} Value indicating whether the controls instance
+     * is currently attached.
+     */
+    public hasCustomCameraControls(controls: ICustomCameraControls): boolean {
+        return this._customCameraControls.has(controls);
+    }
 
     /**
      * Check if a custom renderer has been added to the viewer's

--- a/src/viewer/interfaces/IViewer.ts
+++ b/src/viewer/interfaces/IViewer.ts
@@ -43,6 +43,7 @@ export interface IViewer {
     getPosition(): Promise<LngLat>;
     getReference(): Promise<LngLatAlt>;
     getZoom(): Promise<number>;
+    hasCustomCameraControls(controls: ICustomCameraControls): boolean;
     hasCustomRenderer(rendererId: string): boolean;
     moveDir(direction: NavigationDirection): Promise<Image>;
     moveTo(imageId: string): Promise<Image>;

--- a/test/viewer/CustomCameraControls.test.ts
+++ b/test/viewer/CustomCameraControls.test.ts
@@ -18,6 +18,7 @@ import { CustomCameraControls } from "../../src/viewer/CustomCameraControls";
 import { State } from "../../src/state/State";
 import { ViewportSize } from "../../src/render/interfaces/ViewportSize";
 import { AnimationFrame } from "../../src/state/interfaces/AnimationFrame";
+import { ICustomCameraControls } from "../../src/mapillary";
 
 global.WebGL2RenderingContext = <any>jest.fn();
 
@@ -49,7 +50,50 @@ describe("CustomCameraControls.ctor", () => {
     });
 });
 
-describe("CustomRenderer.attach", () => {
+describe("CustomCameraControls.has", () => {
+    test("should have camera controls immediately after attaching", () => {
+        const navigator = new NavigatorMockCreator().create();
+        const container = new ContainerMockCreator().create();
+        spyOn(Navigator, "Navigator").and.returnValue(navigator);
+        spyOn(Container, "Container").and.returnValue(container);
+
+        const controls = new CustomCameraControls(
+            container,
+            navigator);
+
+        const viewer = <any>{};
+        const custom: ICustomCameraControls = {
+            onActivate: () => { /* noop*/ },
+            onAnimationFrame: () => { /* noop*/ },
+            onAttach: () => { /* noop*/ },
+            onDeactivate: () => { /* noop*/ },
+            onDetach: () => { /* noop*/ },
+            onReference: () => { /* noop */ },
+            onResize: () => { /* noop */ },
+        };
+
+        expect(controls.has(custom)).toBe(false);
+
+        controls.attach(custom, viewer);
+
+        expect(controls.has(custom)).toBe(true);
+
+        const other: ICustomCameraControls = {
+            onActivate: () => { /* noop*/ },
+            onAnimationFrame: () => { /* noop*/ },
+            onAttach: () => { /* noop*/ },
+            onDeactivate: () => { /* noop*/ },
+            onDetach: () => { /* noop*/ },
+            onReference: () => { /* noop */ },
+            onResize: () => { /* noop */ },
+        };
+
+        expect(controls.has(other)).toBe(false);
+
+    });
+});
+
+describe("CustomCameraControls.attach", () => {
     test("should invoke onAttach after gl initialization", done => {
         const navigator = new NavigatorMockCreator().create();
         const container = new ContainerMockCreator().create();
@@ -638,7 +682,7 @@ describe("CustomRenderer.attach", () => {
     });
 });
 
-describe("CustomRenderer.detach", () => {
+describe("CustomCameraControls.detach", () => {
     test("should invoke onDetach when detatching", done => {
         const navigator = new NavigatorMockCreator().create();
         const container = new ContainerMockCreator().create();

--- a/test/viewer/Viewer.test.ts
+++ b/test/viewer/Viewer.test.ts
@@ -153,6 +153,26 @@ describe("Viewer.removeCustomRenderer", () => {
     });
 });
 
+describe("Viewer.hasCustomCameraControls", () => {
+    it("should call custom renderer", () => {
+        const mocks = createMocks();
+        const viewer = new Viewer({ container: "" });
+
+        viewer.hasCustomCameraControls({
+            onActivate: null,
+            onAnimationFrame: null,
+            onAttach: null,
+            onDeactivate: null,
+            onDetach: null,
+            onReference: null,
+            onResize: null,
+        });
+
+        const spy = (<jasmine.Spy>mocks.customCameraControls.has);
+        expect(spy.calls.count()).toBe(1);
+    });
+});
+
 describe("Viewer.triggerRerender", () => {
     it("should call gl renderer", () => {
         const mocks = createMocks();


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make it possible to check if a custom camera controls instance has been attached.

## Contribution

- Add `Viewer.hasCustomCameraControls` method.

## Test Plan

```
yarn build
yarn test
```
