### PR TITLE
Do not uncache spatial on reference change

### DIFF
--- a/src/component/spatial/SpatialCommon.ts
+++ b/src/component/spatial/SpatialCommon.ts
@@ -1,0 +1,21 @@
+import { LngLatAlt } from "../../api/interfaces/LngLatAlt";
+import { enuToGeodetic, geodeticToEnu } from "../../geo/GeoCoords";
+
+export function resetEnu(reference: LngLatAlt, prevEnu: number[], prevReference: LngLatAlt): number[] {
+    const [prevX, prevY, prevZ] = prevEnu;
+    const [lng, lat, alt] = enuToGeodetic(
+        prevX,
+        prevY,
+        prevZ,
+        prevReference.lng,
+        prevReference.lat,
+        prevReference.alt);
+
+    return geodeticToEnu(
+        lng,
+        lat,
+        alt,
+        reference.lng,
+        reference.lat,
+        reference.alt);
+}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Uncaching on reference change leads to a race condition if the browser has internally cached files that are to be fetched. If cells happen to be cached before the reference change is invoked, those cells will be disposed.

## Contribution

- Reset spatial object positions on reference change.
- Do not uncache on reference change.
- Avoid multiple calls to catch cells by publishing cell observable.

## Test Plan

```
yarn test
yarn build
```
