### PR TITLE
Predictable reference reset

### DIFF
--- a/src/state/state/StateBase.ts
+++ b/src/state/state/StateBase.ts
@@ -41,7 +41,7 @@ export abstract class StateBase implements IStateBase {
     constructor(state: IStateBase) {
         this._spatial = new Spatial();
 
-        this._referenceThreshold = 0.01;
+        this._referenceThreshold = 300;
         this._transitionMode = state.transitionMode;
 
         this._reference = state.reference;
@@ -312,13 +312,19 @@ export abstract class StateBase implements IStateBase {
     }
 
     private _setReference(image: Image): boolean {
+        const distance = this._spatial.distanceFromLngLat(
+            image.lngLat.lng,
+            image.lngLat.lat,
+            this.reference.lng,
+            this.reference.lat);
+
         // do not reset reference if image is within threshold distance
-        if (Math.abs(image.lngLat.lat - this.reference.lat) < this._referenceThreshold &&
-            Math.abs(image.lngLat.lng - this.reference.lng) < this._referenceThreshold) {
+        if (distance < this._referenceThreshold) {
             return false;
         }
 
-        // do not reset reference if previous image exist and transition is with motion
+        // do not reset reference if previous image exist and
+        // transition is with motion
         if (this._previousImage != null && !this._motionlessTransition()) {
             return false;
         }

--- a/src/viewer/Observer.ts
+++ b/src/viewer/Observer.ts
@@ -371,6 +371,17 @@ export class Observer {
                     this._viewer.fire(type, event);
                 }));
 
+        subs.push(this._navigator.stateService.reference$
+            .subscribe(
+                (): void => {
+                    const type: ViewerEventType = "position";
+                    const event: ViewerStateEvent = {
+                        target: this._viewer,
+                        type,
+                    };
+                    this._viewer.fire(type, event);
+                }));
+
         subs.push(this._container.renderService.renderCamera$.pipe(
             distinctUntilChanged(
                 ([phi1, theta1], [phi2, theta2]): boolean => {

--- a/test/viewer/Observer.test.ts
+++ b/test/viewer/Observer.test.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from "../../src/util/EventEmitter";
 import { Observer } from "../../src/viewer/Observer";
 import { Viewer } from "../../src/viewer/Viewer";
 import { ViewerDataLoadingEvent } from "../../src/viewer/events/ViewerDataLoadingEvent";
+import { LngLatAlt, ViewerStateEvent } from "../../src/mapillary";
 
 describe("Observer.ctor", () => {
     it("should be defined", () => {
@@ -86,5 +87,31 @@ describe("Observer.dataloading", () => {
         observer.stopEmit();
 
         (<Subject<boolean>>navigatorMock.loadingService.loading$).next(true);
+    });
+});
+
+describe("Observer.position", () => {
+    it("should emit when reference changes", (done: Function) => {
+        const viewer = <Viewer>new EventEmitter();
+        const navigatorMock = new NavigatorMockCreator().create();
+
+        const observer = new Observer(
+            viewer,
+            navigatorMock,
+            new ContainerMockCreator().create());
+        observer.startEmit();
+
+        viewer.on(
+            "position",
+            (event: ViewerStateEvent) => {
+                expect(event.type).toBe("position");
+                done();
+            });
+
+        (<Subject<LngLatAlt>>navigatorMock.stateService.reference$).next({
+            lng: 0,
+            lat: 1,
+            alt: 2
+        });
     });
 });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Make reference reset predictable and stable.

## Contribution

- Reset reference on motionless transition when at least 300 meters from previous reference.
- Emit position change when reference changes (virtual camera pose does not change so reference change should trigger event).

## Test Plan

```
yarn build
yarn test
```
