### PR TITLE
Emit new instances for reference observable

### DIFF
--- a/src/component/spatial/SpatialComponent.ts
+++ b/src/component/spatial/SpatialComponent.ts
@@ -150,8 +150,7 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
         const subs = this._subscriptions;
 
         subs.push(this._navigator.stateService.reference$
-            .pipe(
-                pairwise())
+            .pipe(pairwise())
             .subscribe(
                 ([prevReference, reference]: [LngLatAlt, LngLatAlt]): void => {
                     this._scene.resetReference(reference, prevReference);

--- a/src/state/StateService.ts
+++ b/src/state/StateService.ts
@@ -180,14 +180,16 @@ export class StateService {
         this._reference$ = imageChangedSubject$.pipe(
             map(
                 (f: AnimationFrame): LngLatAlt => {
-                    return f.state.reference;
+                    const { reference } = f.state;
+                    return {
+                        lng: reference.lng,
+                        lat: reference.lat,
+                        alt: reference.alt,
+                    };
                 }),
             distinctUntilChanged(
-                (r1: LngLat, r2: LngLat): boolean => {
+                (r1: LngLatAlt, r2: LngLatAlt): boolean => {
                     return r1.lat === r2.lat && r1.lng === r2.lng;
-                },
-                (reference: LngLatAlt): LngLat => {
-                    return { lat: reference.lat, lng: reference.lng };
                 }),
             publishReplay(1),
             refCount());


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

It is not possible to compare subsequent emitted items downstream if they reference the same object.

## Test Plan

```
yarn test
```
