### PR TITLE
Deactivate combined panning when not traversing

### DIFF
--- a/src/component/image/ImageComponent.ts
+++ b/src/component/image/ImageComponent.ts
@@ -351,10 +351,6 @@ export class ImageComponent extends Component<ComponentConfiguration> {
         subs.push(hasTexture$.subscribe(() => { /*noop*/ }));
 
         subs.push(this._navigator.panService.panImages$.pipe(
-            filter(
-                (panNodes: []): boolean => {
-                    return panNodes.length === 0;
-                }),
             map(
                 (): ImageGLRendererOperation => {
                     return (renderer: ImageGLRenderer): ImageGLRenderer => {
@@ -435,36 +431,30 @@ export class ImageComponent extends Component<ComponentConfiguration> {
                         return trigger;
                     }));
 
-        subs.push(this._navigator.stateService.state$
+        subs.push(this._navigator.panService.panImages$
             .pipe(
-                switchMap(
-                    state => {
-                        return state === State.Traversing ||
-                            state === State.GravityTraversing ?
-                            this._navigator.panService.panImages$ :
-                            observableEmpty();
-
-                    }),
                 switchMap(
                     (nts: [ImageNode, Transform, number][]):
                         Observable<[RenderCamera, ImageNode, Transform, [ImageNode, Transform, number][]]> => {
 
-                        return panTrigger$.pipe(
-                            withLatestFrom(
-                                this._container.renderService.renderCamera$,
-                                this._navigator.stateService.currentImage$,
-                                this._navigator.stateService.currentTransform$),
-                            mergeMap(
-                                ([, renderCamera, currentNode, currentTransform]: [boolean, RenderCamera, ImageNode, Transform]):
-                                    Observable<[RenderCamera, ImageNode, Transform, [ImageNode, Transform, number][]]> => {
-                                    return observableOf(
-                                        [
-                                            renderCamera,
-                                            currentNode,
-                                            currentTransform,
-                                            nts,
-                                        ] as [RenderCamera, ImageNode, Transform, [ImageNode, Transform, number][]]);
-                                }));
+                        return nts.length === 0 ?
+                            observableEmpty() :
+                            panTrigger$.pipe(
+                                withLatestFrom(
+                                    this._container.renderService.renderCamera$,
+                                    this._navigator.stateService.currentImage$,
+                                    this._navigator.stateService.currentTransform$),
+                                mergeMap(
+                                    ([, renderCamera, currentNode, currentTransform]: [boolean, RenderCamera, ImageNode, Transform]):
+                                        Observable<[RenderCamera, ImageNode, Transform, [ImageNode, Transform, number][]]> => {
+                                        return observableOf(
+                                            [
+                                                renderCamera,
+                                                currentNode,
+                                                currentTransform,
+                                                nts,
+                                            ] as [RenderCamera, ImageNode, Transform, [ImageNode, Transform, number][]]);
+                                    }));
                     }),
                 switchMap(
                     ([camera, cn, ct, nts]:

--- a/test/viewer/PanService.test.ts
+++ b/test/viewer/PanService.test.ts
@@ -12,6 +12,7 @@ import { FrameHelper } from "../helper/FrameHelper";
 import { GraphServiceMockCreator } from "../helper/GraphServiceMockCreator";
 import { ImageHelper } from "../helper/ImageHelper";
 import { StateServiceMockCreator } from "../helper/StateServiceMockCreator";
+import { State } from "../../src/state/State";
 
 describe("PanService.ctor", () => {
     it("should be defined when constructed", () => {
@@ -64,6 +65,7 @@ describe("PanService.panImages$", () => {
                 });
 
         (<Subject<AnimationFrame>>stateService.currentState$).next(new FrameHelper().createFrame());
+        (<Subject<State>>stateService.state$).next(State.Traversing);
         (<Subject<Image>>stateService.currentImage$).next(new ImageHelper().createImage());
         (<Subject<LngLatAlt>>stateService.reference$).next({ alt: 0, lat: 0, lng: 0 });
         cacheBoundingBoxSubject.next([]);
@@ -88,6 +90,7 @@ describe("PanService.panImages$", () => {
                 });
 
         (<Subject<AnimationFrame>>stateService.currentState$).next(new FrameHelper().createFrame());
+        (<Subject<State>>stateService.state$).next(State.Traversing);
         (<Subject<Image>>stateService.currentImage$).next(new ImageHelper().createUnmergedImage());
         (<Subject<LngLatAlt>>stateService.reference$).next({ alt: 0, lat: 0, lng: 0 });
         cacheBoundingBoxSubject.next([]);
@@ -113,6 +116,7 @@ describe("PanService.panImages$", () => {
                 });
 
         (<Subject<AnimationFrame>>stateService.currentState$).next(new FrameHelper().createFrame());
+        (<Subject<State>>stateService.state$).next(State.Traversing);
         (<Subject<Image>>stateService.currentImage$).next(new ImageHelper().createImage());
         (<Subject<LngLatAlt>>stateService.reference$).next({ alt: 0, lat: 0, lng: 0 });
         erroredCacheBoundingBoxSubject.error(new Error());
@@ -123,6 +127,7 @@ describe("PanService.panImages$", () => {
         (<jasmine.Spy>graphService.cacheBoundingBox$).and.returnValue(cacheBoundingBoxSubject);
 
         (<Subject<Image>>stateService.currentImage$).next(new ImageHelper().createImage());
+
         (<Subject<LngLatAlt>>stateService.reference$).next({ alt: 0, lat: 0, lng: 0 });
 
         cacheBoundingBoxSubject.next([]);
@@ -151,6 +156,7 @@ describe("PanService.panImages$", () => {
                 });
 
         (<Subject<AnimationFrame>>stateService.currentState$).next(new FrameHelper().createFrame());
+        (<Subject<State>>stateService.state$).next(State.Traversing);
         (<Subject<Image>>stateService.currentImage$).next(new ImageHelper().createImage());
         (<Subject<LngLatAlt>>stateService.reference$).next({ alt: 0, lat: 0, lng: 0 });
         cacheBoundingBoxSubject.next([]);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Combined panning is only relevant in street level traversing states.

## Contribution

- Do not change the current image in non traversing states like earth etc.

## Test Plan

```
yarn test
yarn start
```
