### PR TITLE
Emit null for image on reset

### DIFF
--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -1724,6 +1724,18 @@ declare class Image {
   id: string;
 
   /**
+   * Get is disposed.
+   *
+   * @description If the image has been disposed no properties
+   * are acessible. Image are disposed when the {@link Viewer}
+   * is reset or a new data provider is set.
+   *
+   * @returns {boolean} Value indicating that this image
+   * has been disposed.
+   */
+  isDisposed: boolean;
+
+  /**
    * Get lngLat.
    * @description If the SfM computed longitude, latitude exist
    * it will be returned, otherwise the original EXIF latitude
@@ -3466,7 +3478,7 @@ export type ViewerImageEvent = {
   /**
    * The viewer's current image.
    */
-  image: Image,
+  image: Image | null,
   type: "image",
   ...
 } & ViewerEvent;
@@ -3974,9 +3986,8 @@ declare class Viewer implements IEventEmitter, IViewer {
 
   /**
    * Reset the viewer's cache.
-   * @description All images in the viewer's cache at the moment when
-   * reset is called will eventually be removed if not navigated to
-   * again.
+   * @description All images in the viewer's cache at the moment of the
+   * reset will be disposed.
    * @returns {Promise<void>} Promise that resolves when viewer's cache
    * has been reset.
    * @throws When viewer is not navigable.
@@ -4029,7 +4040,7 @@ declare class Viewer implements IEventEmitter, IViewer {
 
   /**
    * Set a new data provider instance.
-   * @description [object Object],[object Object],[object Object]
+   * @description Resets the viewer's cache (see Viewer.reset).
    * @returns {Promise<void>} Promise that resolves when viewer's data
    * provider has been set.
    * @throws When viewer is not navigable.

--- a/examples/debug/reset.html
+++ b/examples/debug/reset.html
@@ -64,6 +64,9 @@
                 };
                 viewer = new Viewer(options);
                 viewer.on("reset", (event) => console.log(event.type));
+                viewer.on("image", (event) =>
+                    console.log(event.image ? event.image.id : null)
+                );
                 viewer
                     .moveTo(dataProvider.images.keys().next().value)
                     .catch((error) => console.error(error));

--- a/src/graph/Image.ts
+++ b/src/graph/Image.ts
@@ -318,6 +318,20 @@ export class Image {
     }
 
     /**
+     * Get is disposed.
+     *
+     * @description If the image has been disposed no properties
+     * are acessible. Image are disposed when the {@link Viewer}
+     * is reset or a new data provider is set.
+     *
+     * @returns {boolean} Value indicating that this image
+     * has been disposed.
+     */
+    public get isDisposed(): boolean {
+        return !this._core;
+    }
+
+    /**
      * Get lngLat.
      *
      * @description If the SfM computed longitude, latitude exist

--- a/src/state/StateService.ts
+++ b/src/state/StateService.ts
@@ -33,7 +33,6 @@ import { Transform } from "../geo/Transform";
 import { LngLatAlt } from "../api/interfaces/LngLatAlt";
 import { SubscriptionHolder } from "../util/SubscriptionHolder";
 import { Clock } from "three";
-import { isNullImageId } from "../util/Common";
 
 interface IContextOperation {
     (context: IStateContext): IStateContext;
@@ -193,10 +192,6 @@ export class StateService {
             refCount());
 
         this._currentImageExternal$ = imageChanged$.pipe(
-            filter(
-                (f: AnimationFrame): boolean => {
-                    return !isNullImageId(f.state.currentImage.id);
-                }),
             map(
                 (f: AnimationFrame): Image => {
                     return f.state.currentImage;

--- a/src/viewer/Observer.ts
+++ b/src/viewer/Observer.ts
@@ -41,6 +41,7 @@ import { ViewerLoadEvent } from "./events/ViewerLoadEvent";
 import { ViewerReferenceEvent } from "./events/ViewerReferenceEvent";
 import { ViewerResetEvent } from "./events/ViewerResetEvent";
 import { ViewerDragEndEvent } from "./events/ViewerDragEndEvent";
+import { isNullImageId } from "../util/Common";
 
 type UnprojectionParams = [
     [
@@ -200,7 +201,7 @@ export class Observer {
             .subscribe((image: Image): void => {
                 const type: ViewerEventType = "image";
                 const event: ViewerImageEvent = {
-                    image,
+                    image: isNullImageId(image.id) ? null : image,
                     target: this._viewer,
                     type,
                 };

--- a/src/viewer/PanService.ts
+++ b/src/viewer/PanService.ts
@@ -12,6 +12,7 @@ import {
 import {
     catchError,
     distinctUntilChanged,
+    filter,
     map,
     publishReplay,
     refCount,
@@ -37,6 +38,7 @@ import { isSpherical } from "../geo/Geo";
 import { geodeticToEnu } from "../geo/GeoCoords";
 import { State } from "../state/State";
 import { ICameraFactory } from "../geometry/interfaces/ICameraFactory";
+import { isNullImageId } from "../util/Common";
 
 enum PanMode {
     Disabled,
@@ -126,6 +128,7 @@ export class PanService {
         }
 
         const panImages$ = this._stateService.currentImage$.pipe(
+            filter((image: Image) => { return !isNullImageId(image.id); }),
             switchMap(
                 (current: Image): Observable<[Image, Transform, number][]> => {
                     if (!current.merged || isSpherical(current.cameraType)) {

--- a/src/viewer/Viewer.ts
+++ b/src/viewer/Viewer.ts
@@ -1431,9 +1431,8 @@ export class Viewer extends EventEmitter implements IViewer {
     /**
      * Reset the viewer's cache.
      *
-     * @description All images in the viewer's cache at the moment when
-     * reset is called will eventually be removed if not navigated to
-     * again.
+     * @description All images in the viewer's cache at the moment of the
+     * reset will be disposed.
      *
      * @returns {Promise<void>} Promise that resolves when viewer's cache
      * has been reset.

--- a/src/viewer/events/ViewerImageEvent.ts
+++ b/src/viewer/events/ViewerImageEvent.ts
@@ -7,8 +7,11 @@ import { Image } from "../../graph/Image";
 export interface ViewerImageEvent extends ViewerEvent {
     /**
      * The viewer's current image.
+     *
+     * @description If the viewer is reset, the emitted
+     * image will be null.
      */
-    image: Image;
+    image: Image | null;
 
     type: "image";
 }


### PR DESCRIPTION
When viewer is reset, no current image is set anymore so emit null for clarity.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The selected image is disposed on reset, emit null to ensure clarity.

## Contribution

- Add  `isDisposed` property to Image class
- Emit null when graph is reset

## Test Plan

```
yarn test
yarn prepare
yarn start
```