### PR TITLE
Do not apply spherical lookat after reset

### DIFF
--- a/src/state/state/TraversingState.ts
+++ b/src/state/state/TraversingState.ts
@@ -4,6 +4,7 @@ import { InteractiveStateBase } from "./InteractiveStateBase";
 import { IStateBase } from "../interfaces/IStateBase";
 import { Image } from "../../graph/Image";
 import { isSpherical } from "../../geo/Geo";
+import { isNullImageId } from "../../util/Common";
 
 export class TraversingState extends InteractiveStateBase {
 
@@ -136,8 +137,11 @@ export class TraversingState extends InteractiveStateBase {
         let lookat: THREE.Vector3 = this._camera.lookat.clone().sub(this._camera.position);
         this._previousCamera.lookat.copy(lookat.clone().add(this._previousCamera.position));
 
-        if (isSpherical(this._currentImage.cameraType)) {
-            this._currentCamera.lookat.copy(lookat.clone().add(this._currentCamera.position));
+        if (
+            isSpherical(this._currentImage.cameraType) &&
+            !isNullImageId(this._previousImage.id)) {
+            this._currentCamera.lookat.copy(
+                lookat.clone().add(this._currentCamera.position));
         }
     }
 


### PR DESCRIPTION
Avoid looking up after reset.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensure that spherical lookat points to center of image after reset.

## Test Plan

```
yarn prepare
yarn start
```

