### PR TITLE
Event api to delete cluster from graph

### DIFF
--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -585,7 +585,7 @@ export interface ImageTilesRequestContract {
 /**
  * @event
  */
-export type ProviderEventType = "datacreate";
+export type ProviderEventType = "datacreate" | "datadelete";
 /**
  * @interface IGeometryProvider
  *
@@ -773,6 +773,22 @@ export type ProviderCellEvent = {
    * Provider event type.
    */
   type: "datacreate",
+  ...
+} & ProviderEvent;
+/**
+ *
+ * Interface for data provider cluster events.
+ */
+export type ProviderClusterEvent = {
+  /**
+   * Cluster ids for clusters that have been deleted.
+   */
+  clusterIds: string[],
+
+  /**
+   * Provider event type.
+   */
+  type: "datadelete",
   ...
 } & ProviderEvent;
 

--- a/doc/.eslintrc.js
+++ b/doc/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
     'react-hooks/rules-of-hooks': ERROR,
     'react/prop-types': OFF, // PropTypes aren't used much these days.
     'no-console': ['error', {allow: ['info', 'warn', 'error']}],
+    'no-continue': OFF,
     'no-underscore-dangle': ['error', {allowAfterThis: true}],
     'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
     'no-restricted-syntax': [

--- a/doc/src/js/utils/ChunkDataProvider.js
+++ b/doc/src/js/utils/ChunkDataProvider.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {
+  DataProviderBase,
+  S2GeometryProvider,
+} from '../../mapillary-js/dist/mapillary.module';
+
+import {generateCells, generateImageBuffer} from './provider';
+
+const IMAGE_TILE_SIZE = 10;
+const IMAGE_TILES_Y = 10;
+
+export const REFERENCE = {alt: 0, lat: 0, lng: 0};
+
+export class ChunkDataProvider extends DataProviderBase {
+  constructor() {
+    super(new S2GeometryProvider());
+
+    this.chunks = new Map();
+    this.cells = new Map();
+    this.clusters = new Map();
+    this.images = new Map();
+    this.sequences = new Map();
+  }
+
+  addChunk(chunk) {
+    if (this.chunks.has(chunk.id)) {
+      throw new Error(`Chunk already exists ${chunk.id}`);
+    }
+
+    const {cluster, images, sequence} = chunk;
+
+    if (this.clusters.has(cluster.id)) {
+      throw new Error(`Cluster already exists ${cluster.id}`);
+    }
+    if (this.sequences.has(sequence.id)) {
+      throw new Error(`Sequence already exists ${sequence.id}`);
+    }
+    for (const imageId of images.keys()) {
+      if (this.images.has(imageId)) {
+        throw new Error(`Image already exists ${imageId}`);
+      }
+    }
+
+    this.chunks.set(chunk.id, chunk);
+    this.clusters.set(cluster.id, cluster);
+    this.sequences.set(sequence.id, sequence);
+
+    for (const image of images.values()) {
+      this.images.set(image.id, image);
+    }
+    const cells = generateCells(this.images.values(), this._geometry);
+    for (const [cellId, cellImages] of cells.entries()) {
+      if (!this.cells.has(cellId)) {
+        this.cells.set(cellId, new Map());
+      }
+      const cell = this.cells.get(cellId);
+      for (const cellImage of cellImages) {
+        cell.set(cellImage.id, cellImage);
+      }
+    }
+
+    const dataCreateEvent = {
+      cellIds: Array.from(cells.keys()),
+      target: this,
+      type: 'datacreate',
+    };
+    this.fire(dataCreateEvent.type, dataCreateEvent);
+  }
+
+  deleteChunks(chunkIds) {
+    for (const chunkId of chunkIds) {
+      if (!this.chunks.has(chunkId)) {
+        throw new Error(`Chunk does not exist ${chunkId}`);
+      }
+
+      const {cluster, images, sequence} = this.chunks.get(chunkId);
+
+      this.chunks.delete(chunkId);
+      this.clusters.delete(cluster.id);
+      this.sequences.delete(sequence.id);
+
+      for (const image of images.values()) {
+        this.images.delete(image.id);
+        const cellId = this._geometry.lngLatToCellId(image.geometry);
+        this.cells.get(cellId).delete(image.id);
+      }
+    }
+
+    const dataDeleteEvent = {
+      clusterIds: chunkIds,
+      target: this,
+      type: 'datadelete',
+    };
+    this.fire(dataDeleteEvent.type, dataDeleteEvent);
+  }
+
+  getCluster(url) {
+    if (this.clusters.has(url)) {
+      return Promise.resolve(this.clusters.get(url));
+    }
+
+    return Promise.reject(new Error(`Cluster does not exist ${url}`));
+  }
+
+  getCoreImages(cellId) {
+    const images = this.cells.has(cellId) ? this.cells.get(cellId) : new Map();
+    return Promise.resolve({
+      cell_id: cellId,
+      images: Array.from(images.values()),
+    });
+  }
+
+  getImages(imageIds) {
+    const images = [];
+    for (const imageId of imageIds) {
+      if (!this.images.has(imageId)) {
+        return Promise.reject(new Error(`Image does not exist ${imageId}`));
+      }
+      images.push({
+        node: this.images.get(imageId),
+        node_id: imageId,
+      });
+    }
+    return Promise.resolve(images);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getImageBuffer(url) {
+    return generateImageBuffer({
+      tileSize: IMAGE_TILE_SIZE,
+      tilesY: IMAGE_TILES_Y,
+      url,
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getMesh(_url) {
+    return Promise.resolve({faces: [], vertices: []});
+  }
+
+  getSequence(sequenceId) {
+    if (this.sequences.has(sequenceId)) {
+      return Promise.resolve(this.sequences.get(sequenceId));
+    }
+
+    return Promise.reject(new Error(`Sequence does not exist ${sequenceId}`));
+  }
+
+  getSpatialImages(imageIds) {
+    return this.getImages(imageIds);
+  }
+}

--- a/doc/src/js/utils/DeletableProceduralDataProvider.js
+++ b/doc/src/js/utils/DeletableProceduralDataProvider.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {ProceduralDataProvider} from './ProceduralDataProvider';
+
+export class DeletableProceduralDataProvider extends ProceduralDataProvider {
+  delete() {
+    if (!this.clusters.size) {
+      return;
+    }
+
+    const clusterId = this.clusters.keys().next().value;
+    this.clusters.delete(clusterId);
+
+    for (const [imageId, image] of this.images.entries()) {
+      if (image.cluster.id !== clusterId) {
+        continue;
+      }
+
+      this.images.delete(imageId);
+      this.sequences.delete(image.sequence.id);
+      for (const cellImages of this.cells.values()) {
+        const index = cellImages.indexOf(image);
+        if (index !== -1) {
+          cellImages.splice(index, 1);
+        }
+      }
+    }
+
+    this._fire([clusterId]);
+  }
+
+  _fire(clusterIds) {
+    const target = this;
+    const type = 'datadelete';
+    const event = {
+      clusterIds,
+      target,
+      type,
+    };
+    this.fire(type, event);
+  }
+}

--- a/doc/src/js/utils/ProceduralDataProvider.js
+++ b/doc/src/js/utils/ProceduralDataProvider.js
@@ -8,145 +8,22 @@
  */
 
 import {
-  enuToGeodetic,
   DataProviderBase,
   S2GeometryProvider,
 } from '../../mapillary-js/dist/mapillary.module';
 
-import {generateImageBuffer} from './image';
-
-const ASPECT_FISHEYE = 3 / 2;
-const ASPECT_PERSPECTIVE = 4 / 3;
-const ASPECT_SPHERICAL = 2;
-
-const FISHEYE = 'fisheye';
-const PERSPECTIVE = 'perspective';
-const SPHERICAL = 'spherical';
+import {
+  CAMERA_TYPE_FISHEYE,
+  CAMERA_TYPE_PERSPECTIVE,
+  CAMERA_TYPE_SPHERICAL,
+  cameraTypeToAspect,
+  generateCells,
+  generateCluster,
+  generateImageBuffer,
+} from './provider';
 
 export const DEFAULT_REFERENCE = {alt: 0, lat: 0, lng: 0};
 export const DEFAULT_INTERVALS = 10;
-
-function cameraTypeToAspect(cameraType) {
-  switch (cameraType) {
-    case FISHEYE:
-      return ASPECT_FISHEYE;
-    case PERSPECTIVE:
-      return ASPECT_PERSPECTIVE;
-    case SPHERICAL:
-      return ASPECT_SPHERICAL;
-    default:
-      throw new Error(`Camera type ${cameraType} not supported`);
-  }
-}
-
-function generateCells(images, geometryProvider) {
-  const cells = new Map();
-  for (const image of images) {
-    const cellId = geometryProvider.lngLatToCellId(image.geometry);
-    if (!cells.has(cellId)) {
-      cells.set(cellId, []);
-    }
-    cells.get(cellId).push(image);
-  }
-  return cells;
-}
-
-function generateCluster(options, intervals) {
-  const {cameraType, color, east, focal, height, k1, k2, width} = options;
-  let {idCounter} = options;
-  const {alt, lat, lng} = options.reference;
-
-  const distance = 5;
-
-  const images = [];
-  const thumbUrl = `${cameraType}`;
-  const clusterId = `cluster|${cameraType}`;
-  const sequenceId = `sequence|${cameraType}`;
-  const sequence = {id: sequenceId, image_ids: []};
-
-  const start = idCounter;
-  const end = idCounter + intervals;
-
-  while (idCounter <= end) {
-    const imageId = `image|${cameraType}|${idCounter}`;
-    const thumbId = `thumb|${cameraType}|${idCounter}`;
-    const meshId = `mesh|${cameraType}|${idCounter}`;
-    sequence.image_ids.push(imageId);
-
-    const index = idCounter - start;
-    const north = (-intervals * distance) / 2 + distance * index;
-    const up = 0;
-    const [computedLng, computedLat, computedAlt] = enuToGeodetic(
-      east,
-      north,
-      up,
-      lng,
-      lat,
-      alt,
-    );
-    const computedGeometry = {lat: computedLat, lng: computedLng};
-    const rotation = [Math.PI / 2, 0, 0];
-    const compassAngle = 0;
-    const cameraParameters = cameraType === SPHERICAL ? [] : [focal, k1, k2];
-
-    images.push({
-      altitude: computedAlt,
-      atomic_scale: 1,
-      camera_parameters: cameraParameters,
-      camera_type: cameraType,
-      captured_at: 0,
-      cluster: {id: clusterId, url: clusterId},
-      computed_rotation: rotation,
-      compass_angle: compassAngle,
-      computed_compass_angle: compassAngle,
-      computed_altitude: computedAlt,
-      computed_geometry: computedGeometry,
-      creator: {id: null, username: null},
-      geometry: computedGeometry,
-      height,
-      id: imageId,
-      merge_id: 'merge_id',
-      mesh: {id: meshId, url: meshId},
-      exif_orientation: 1,
-      private: null,
-      quality_score: 1,
-      sequence: {id: sequenceId},
-      thumb: {id: thumbId, url: thumbUrl},
-      owner: {id: null},
-      width,
-    });
-
-    idCounter += 1;
-  }
-
-  const cluster = {
-    colors: [],
-    coordinates: [],
-    id: clusterId,
-    pointIds: [],
-    reference: options.reference,
-  };
-  for (let i = 0; i <= intervals; i++) {
-    const easts = [-3, 3];
-    const north = (-intervals * distance) / 2 + distance * i;
-    const up = 0;
-    for (let y = 0; y < distance; y++) {
-      for (let z = 0; z < distance; z++) {
-        for (const x of easts) {
-          const pointId = `${i}-${z}-${y}-${x}`;
-          const cx = east + x;
-          const cy = north + y;
-          const cz = up + z;
-          cluster.pointIds.push(pointId);
-          cluster.coordinates.push(cx, cy, cz);
-          cluster.colors.push(...color);
-        }
-      }
-    }
-  }
-
-  return {cluster, images, sequence};
-}
 
 function generateClusters(options) {
   const {height, intervals, reference} = options;
@@ -158,7 +35,7 @@ function generateClusters(options) {
 
   const clusterConfigs = [
     {
-      cameraType: PERSPECTIVE,
+      cameraType: CAMERA_TYPE_PERSPECTIVE,
       color: [1, 0, 0],
       east: -9,
       focal: 0.8,
@@ -167,7 +44,7 @@ function generateClusters(options) {
       reference,
     },
     {
-      cameraType: FISHEYE,
+      cameraType: CAMERA_TYPE_FISHEYE,
       color: [0, 1, 0],
       east: 9,
       focal: 0.45,
@@ -176,7 +53,7 @@ function generateClusters(options) {
       reference,
     },
     {
-      cameraType: SPHERICAL,
+      cameraType: CAMERA_TYPE_SPHERICAL,
       color: [1, 1, 0],
       east: 0,
       reference,
@@ -200,16 +77,6 @@ function generateClusters(options) {
     images: new Map(images.map((i) => [i.id, i])),
     sequences: new Map(sequences.map((s) => [s.id, s])),
   };
-}
-
-function getImageBuffer(options) {
-  const {tileSize, tilesY, url} = options;
-  const aspect = cameraTypeToAspect(url);
-  return generateImageBuffer({
-    tileSize,
-    tilesX: aspect * tilesY,
-    tilesY,
-  });
 }
 
 export class ProceduralDataProvider extends DataProviderBase {
@@ -249,7 +116,7 @@ export class ProceduralDataProvider extends DataProviderBase {
   getImageBuffer(url) {
     const {imageTileSize, imageTilesY} = this;
     const options = {tileSize: imageTileSize, tilesY: imageTilesY, url};
-    return getImageBuffer(options);
+    return generateImageBuffer(options);
   }
 
   getMesh(url) {

--- a/doc/src/js/utils/provider.js
+++ b/doc/src/js/utils/provider.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import {enuToGeodetic} from '../../mapillary-js/dist/mapillary.module';
+
+import {generateImageBuffer as genImageBuffer} from './image';
+
+const ASPECT_FISHEYE = 3 / 2;
+const ASPECT_PERSPECTIVE = 4 / 3;
+const ASPECT_SPHERICAL = 2;
+
+export const CAMERA_TYPE_FISHEYE = 'fisheye';
+export const CAMERA_TYPE_PERSPECTIVE = 'perspective';
+export const CAMERA_TYPE_SPHERICAL = 'spherical';
+
+export function cameraTypeToAspect(cameraType) {
+  switch (cameraType) {
+    case CAMERA_TYPE_FISHEYE:
+      return ASPECT_FISHEYE;
+    case CAMERA_TYPE_PERSPECTIVE:
+      return ASPECT_PERSPECTIVE;
+    case CAMERA_TYPE_SPHERICAL:
+      return ASPECT_SPHERICAL;
+    default:
+      throw new Error(`Camera type ${cameraType} not supported`);
+  }
+}
+
+export function generateImageBuffer(options) {
+  const {tileSize, tilesY, url} = options;
+  const aspect = cameraTypeToAspect(url);
+  return genImageBuffer({
+    tileSize,
+    tilesX: aspect * tilesY,
+    tilesY,
+  });
+}
+
+export function generateCells(images, geometryProvider) {
+  const cells = new Map();
+  for (const image of images) {
+    const cellId = geometryProvider.lngLatToCellId(image.geometry);
+    if (!cells.has(cellId)) {
+      cells.set(cellId, []);
+    }
+    cells.get(cellId).push(image);
+  }
+  return cells;
+}
+
+export function generateCluster(options, intervals) {
+  const {cameraType, color, east, focal, height, id, k1, k2, width} = options;
+  let {idCounter} = options;
+  const {alt, lat, lng} = options.reference;
+
+  const distance = 5;
+
+  const images = [];
+  const thumbUrl = `${cameraType}`;
+  const clusterId = id ?? `cluster|${cameraType}`;
+  const sequenceId = id ?? `sequence|${cameraType}`;
+  const sequence = {id: sequenceId, image_ids: []};
+
+  const start = idCounter;
+  const end = idCounter + intervals;
+
+  while (idCounter <= end) {
+    const imageId = id
+      ? `image|${id}|${cameraType}|${idCounter}`
+      : `image|${cameraType}|${idCounter}`;
+    const thumbId = `thumb|${cameraType}|${idCounter}`;
+    const meshId = `mesh|${cameraType}|${idCounter}`;
+    sequence.image_ids.push(imageId);
+
+    const index = idCounter - start;
+    const north = (-intervals * distance) / 2 + distance * index;
+    const up = 0;
+    const [computedLng, computedLat, computedAlt] = enuToGeodetic(
+      east,
+      north,
+      up,
+      lng,
+      lat,
+      alt,
+    );
+    const computedGeometry = {lat: computedLat, lng: computedLng};
+    const rotation = [Math.PI / 2, 0, 0];
+    const compassAngle = 0;
+    const cameraParameters =
+      cameraType === CAMERA_TYPE_SPHERICAL ? [] : [focal, k1, k2];
+
+    images.push({
+      altitude: computedAlt,
+      atomic_scale: 1,
+      camera_parameters: cameraParameters,
+      camera_type: cameraType,
+      captured_at: 0,
+      cluster: {id: clusterId, url: clusterId},
+      computed_rotation: rotation,
+      compass_angle: compassAngle,
+      computed_compass_angle: compassAngle,
+      computed_altitude: computedAlt,
+      computed_geometry: computedGeometry,
+      creator: {id: null, username: null},
+      geometry: computedGeometry,
+      height,
+      id: imageId,
+      merge_id: 'merge_id',
+      mesh: {id: meshId, url: meshId},
+      exif_orientation: 1,
+      private: null,
+      quality_score: 1,
+      sequence: {id: sequenceId},
+      thumb: {id: thumbId, url: thumbUrl},
+      owner: {id: null},
+      width,
+    });
+
+    idCounter += 1;
+  }
+
+  const cluster = {
+    colors: [],
+    coordinates: [],
+    id: clusterId,
+    pointIds: [],
+    reference: options.reference,
+  };
+  for (let i = 0; i <= intervals; i++) {
+    const easts = [-3, 3];
+    const north = (-intervals * distance) / 2 + distance * i;
+    const up = 0;
+    for (let y = 0; y < distance; y++) {
+      for (let z = 0; z < distance; z++) {
+        for (const x of easts) {
+          const pointId = `${i}-${z}-${y}-${x}`;
+          const cx = east + x;
+          const cy = north + y;
+          const cz = up + z;
+          cluster.pointIds.push(pointId);
+          cluster.coordinates.push(cx, cy, cz);
+          cluster.colors.push(...color);
+        }
+      }
+    }
+  }
+
+  return {cluster, images, sequence};
+}

--- a/examples/debug/chunk.html
+++ b/examples/debug/chunk.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Chunk</title>
+        <link rel="icon" href="data:," />
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, user-scalable=no"
+        />
+
+        <link rel="stylesheet" href="/dist/mapillary.css" />
+
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            html,
+            body,
+            .viewer {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+    </head>
+
+    <body>
+        <script type="module">
+            import { accessToken } from "/doc-src/.access-token/token.js";
+            import {
+                CameraControls,
+                Viewer,
+                S2GeometryProvider,
+            } from "/dist/mapillary.module.js";
+            import { ChunkDataProvider } from "/doc-src/src/js/utils/ChunkDataProvider.js";
+            import {
+                CAMERA_TYPE_SPHERICAL,
+                cameraTypeToAspect,
+                generateCluster,
+            } from "/doc-src/src/js/utils/provider.js";
+
+            let viewer;
+            let dataProvider;
+            let chunks;
+            let chunkCounter = 0;
+
+            const INTERVALS = 1;
+            const REFERENCE = { alt: 0, lat: 0, lng: 0 };
+
+            (function main() {
+                const container = document.createElement("div");
+                container.className = "viewer";
+                document.body.append(container);
+
+                dataProvider = new ChunkDataProvider({
+                    geometry: new S2GeometryProvider(18),
+                });
+                const options = {
+                    dataProvider,
+                    cameraControls: CameraControls.Earth,
+                    component: {
+                        cover: false,
+                        image: false,
+                        spatial: {
+                            cameraSize: 0.3,
+                            cellGridDepth: 2,
+                            cellsVisible: true,
+                        },
+                    },
+                    container,
+                    imageTiling: false,
+                };
+                viewer = new Viewer(options);
+                chunks = [];
+
+                listen();
+            })();
+
+            function generateChunk() {
+                const cameraType = CAMERA_TYPE_SPHERICAL;
+                const aspect = cameraTypeToAspect(cameraType);
+                const height = 100;
+                const counter = chunks.length;
+                const shift = counter * 10;
+                const mod = 3;
+                const config = {
+                    cameraType,
+                    color: [1, (counter % mod) / (mod - 1), 0],
+                    east: shift,
+                    height,
+                    id: counter.toString(),
+                    idCounter: counter * (INTERVALS + 1),
+                    reference: REFERENCE,
+                    width: aspect * height,
+                };
+
+                const chunk = generateCluster(config, INTERVALS);
+                chunk.id = chunk.cluster.id;
+                return chunk;
+            }
+
+            function listen() {
+                window.document.addEventListener("keydown", (e) => {
+                    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+                        return;
+                    }
+
+                    try {
+                        switch (e.key) {
+                            case "q": {
+                                // Move to first
+                                const imageId = dataProvider.images
+                                    .keys()
+                                    .next().value;
+                                viewer
+                                    .moveTo(imageId)
+                                    .catch((error) => console.error(error));
+                                break;
+                            }
+                            case "w": {
+                                // Add a chunk
+                                const added = generateChunk();
+                                console.log(`Add chunk ${added.id}`);
+                                chunks.push(added);
+                                dataProvider.addChunk(added);
+                                break;
+                            }
+                            case "e": {
+                                // Delete last chunk
+                                if (!chunks.length) {
+                                    console.log("No chunk to delete");
+                                    break;
+                                }
+
+                                const deleted = chunks.pop();
+                                console.log(`Delete chunk ${deleted.id}`);
+                                dataProvider.deleteChunks([deleted.id]);
+                                break;
+                            }
+                            case "r": {
+                                // Delete all except first chunk
+                                if (!chunks.length) {
+                                    console.log("No chunks to delete");
+                                    break;
+                                }
+
+                                const deleted = chunks
+                                    .splice(1)
+                                    .map((chunk) => chunk.id);
+                                console.log(`Delete chunks ${deleted}`);
+                                dataProvider.deleteChunks(deleted);
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    } catch (error) {
+                        console.log(error);
+                    }
+                });
+            }
+        </script>
+    </body>
+</html>

--- a/examples/debug/delete.html
+++ b/examples/debug/delete.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Delete</title>
+        <link rel="icon" href="data:," />
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, user-scalable=no"
+        />
+
+        <link rel="stylesheet" href="/dist/mapillary.css" />
+
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            html,
+            body,
+            .viewer {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+    </head>
+
+    <body>
+        <script type="module">
+            import { accessToken } from "/doc-src/.access-token/token.js";
+            import {
+                CameraControls,
+                Viewer,
+                S2GeometryProvider,
+            } from "/dist/mapillary.module.js";
+            import { DeletableProceduralDataProvider } from "/doc-src/src/js/utils/DeletableProceduralDataProvider.js";
+
+            let viewer;
+            let dataProvider;
+
+            (function main() {
+                const container = document.createElement("div");
+                container.className = "viewer";
+                document.body.append(container);
+
+                dataProvider = new DeletableProceduralDataProvider({
+                    geometry: new S2GeometryProvider(18),
+                });
+                const options = {
+                    dataProvider,
+                    cameraControls: CameraControls.Earth,
+                    component: {
+                        cover: false,
+                        spatial: {
+                            cameraSize: 0.3,
+                            cellGridDepth: 2,
+                            cellsVisible: true,
+                        },
+                    },
+                    container,
+                    imageTiling: false,
+                };
+                viewer = new Viewer(options);
+                viewer
+                    .moveTo(dataProvider.images.keys().next().value)
+                    .catch((error) => console.error(error));
+
+                listen();
+            })();
+
+            function listen() {
+                window.document.addEventListener("keydown", (e) => {
+                    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+                        return;
+                    }
+
+                    try {
+                        switch (e.key) {
+                            case "q": {
+                                // Delete a random cluster
+                                dataProvider.delete();
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    } catch (error) {
+                        console.log(error);
+                    }
+                });
+            }
+        </script>
+    </body>
+</html>

--- a/examples/debug/reset.html
+++ b/examples/debug/reset.html
@@ -69,10 +69,12 @@
                 };
                 viewer = new Viewer(options);
                 viewer.on("image", (event) =>
-                    console.log(event.image ? event.image.id : null)
+                    console.log("image", event.image ? event.image.id : null)
                 );
-                viewer.on("reference", (event) => console.log(event));
-                viewer.on("reset", (event) => console.log(event));
+                viewer.on("reference", (event) =>
+                    console.log("reference", event)
+                );
+                viewer.on("reset", (event) => console.log("reset", event));
                 viewer
                     .moveTo(dataProvider.images.keys().next().value)
                     .catch((error) => console.error(error));

--- a/examples/debug/spatial.html
+++ b/examples/debug/spatial.html
@@ -66,6 +66,7 @@
             let hoveredImageId = null;
             let paintedClusterId = null;
             viewer.on("mousemove", async (event) => {
+                return;
                 function paintCluster(clusterId, color) {
                     spatial.setPointOverrideColor(clusterId, color);
                     spatial.setCameraOverrideColor(clusterId, color);

--- a/src/api/DataProviderBase.ts
+++ b/src/api/DataProviderBase.ts
@@ -15,6 +15,7 @@ import { ProviderEvent } from "./events/ProviderEvent";
 import { ProviderCellEvent } from "./events/ProviderCellEvent";
 import { IDataProvider } from "./interfaces/IDataProvider";
 import { IGeometryProvider } from "./interfaces/IGeometryProvider";
+import { ProviderClusterEvent } from "./events/ProviderClusterEvent";
 
 /**
  * @class DataProviderBase
@@ -84,6 +85,10 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
     public fire(
         type: "datacreate",
         event: ProviderCellEvent)
+        : void;
+    public fire(
+        type: "datadelete",
+        event: ProviderClusterEvent)
         : void;
     /** @ignore */
     public fire(
@@ -225,6 +230,10 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
         type: ProviderCellEvent["type"],
         handler: (event: ProviderCellEvent) => void)
         : void;
+    public off(
+        type: ProviderClusterEvent["type"],
+        handler: (event: ProviderClusterEvent) => void)
+        : void;
     /** @ignore */
     public off(
         type: ProviderEventType,
@@ -258,6 +267,10 @@ export abstract class DataProviderBase extends EventEmitter implements IDataProv
     public on(
         type: "datacreate",
         handler: (event: ProviderCellEvent) => void)
+        : void;
+    public on(
+        type: "datadelete",
+        handler: (event: ProviderClusterEvent) => void)
         : void;
     /** @ignore */
     public on(

--- a/src/api/events/ProviderClusterEvent.ts
+++ b/src/api/events/ProviderClusterEvent.ts
@@ -1,0 +1,17 @@
+import { ProviderEvent } from "./ProviderEvent";
+
+/**
+ *
+ * Interface for data provider cluster events.
+ */
+export interface ProviderClusterEvent extends ProviderEvent {
+    /**
+     * Cluster ids for clusters that have been deleted.
+     */
+    clusterIds: string[];
+
+    /**
+     * Provider event type.
+     */
+    type: "datadelete";
+}

--- a/src/api/events/ProviderEventType.ts
+++ b/src/api/events/ProviderEventType.ts
@@ -2,4 +2,5 @@
  * @event
  */
 export type ProviderEventType =
-    | "datacreate";
+    | "datacreate"
+    | "datadelete";

--- a/src/api/interfaces/IDataProvider.ts
+++ b/src/api/interfaces/IDataProvider.ts
@@ -13,6 +13,7 @@ import { ProviderEventType } from "../events/ProviderEventType";
 import { ProviderEvent } from "../events/ProviderEvent";
 import { ProviderCellEvent } from "../events/ProviderCellEvent";
 import { IGeometryProvider } from "./IGeometryProvider";
+import { ProviderClusterEvent } from "../events/ProviderClusterEvent";
 
 /**
  * @interface IDataProvider
@@ -62,6 +63,37 @@ export interface IDataProvider extends EventEmitter {
     fire(
         type: "datacreate",
         event: ProviderCellEvent)
+        : void;
+    /**
+     * Fire when data has been created in the data provider
+     * after initial load.
+     *
+     * @param type datacreate
+     * @param event Provider cell event
+     *
+     * @example
+     * ```js
+     * // Initialize the data provider
+     * class MyDataProvider extends DataProviderBase {
+     *   // Class implementation
+     * }
+     * var provider = new MyDataProvider();
+     * // Create the event
+     * var clusterIds = [ // Determine deleted clusters ];
+     * var target = provider;
+     * var type = "datadelete";
+     * var event = {
+     *   clusterIds,
+     *   target,
+     *   type,
+     * };
+     * // Fire the event
+     * provider.fire(type, event);
+     * ```
+     */
+    fire(
+        type: "datadelete",
+        event: ProviderClusterEvent)
         : void;
     /** @ignore */
     fire(
@@ -183,6 +215,10 @@ export interface IDataProvider extends EventEmitter {
         type: ProviderCellEvent["type"],
         handler: (event: ProviderCellEvent) => void)
         : void;
+    off(
+        type: ProviderClusterEvent["type"],
+        handler: (event: ProviderClusterEvent) => void)
+        : void;
     /** @ignore */
     off(
         type: ProviderEventType,
@@ -215,6 +251,28 @@ export interface IDataProvider extends EventEmitter {
     on(
         type: "datacreate",
         handler: (event: ProviderCellEvent) => void)
+        : void;
+    /**
+     * Fired when data has been deleted in the data provider
+     * after initial load.
+     *
+     * @event datacreate
+     * @example
+     * ```js
+     * // Initialize the data provider
+     * class MyDataProvider extends DataProviderBase {
+     *   // implementation
+     * }
+     * var provider = new MyDataProvider();
+     * // Set an event listener
+     * provider.on("datadelete", function() {
+     *   console.log("A datacreate event has occurred.");
+     * });
+     * ```
+     */
+    on(
+        type: "datadelete",
+        handler: (event: ProviderClusterEvent) => void)
         : void;
     /** @ignore */
     on(

--- a/src/component/spatial/SpatialComponent.ts
+++ b/src/component/spatial/SpatialComponent.ts
@@ -597,6 +597,15 @@ export class SpatialComponent extends Component<SpatialConfiguration> {
                 }))
             .subscribe(this._container.glRenderer.render$));
 
+        subs.push(this._navigator.graphService.dataDeleted$
+            .subscribe(
+                (clusterIds: string[]): void => {
+                    for (const clusterId of clusterIds) {
+                        this._cache.removeCluster(clusterId);
+                        this._scene.uncacheCluster(clusterId);
+                    }
+                }));
+
         const updatedCell$ = this._navigator.graphService.dataAdded$
             .pipe(
                 filter(

--- a/src/external/api.ts
+++ b/src/external/api.ts
@@ -35,6 +35,7 @@ export { S2GeometryProvider } from "../api/S2GeometryProvider";
 
 // Event
 export { ProviderCellEvent } from "../api/events/ProviderCellEvent";
+export { ProviderClusterEvent } from "../api/events/ProviderClusterEvent";
 export { ProviderEvent } from "../api/events/ProviderEvent";
 export { ProviderEventType } from "../api/events/ProviderEventType";
 

--- a/src/graph/Image.ts
+++ b/src/graph/Image.ts
@@ -332,6 +332,19 @@ export class Image {
     }
 
     /**
+     * Get is complete.
+     *
+     * @returns {boolean} Value indicating that this image
+     * is complete.
+     *
+     * @ignore
+     */
+    public get isComplete(): boolean {
+        return !!this._core && !!this._spatial;
+    }
+
+
+    /**
      * Get lngLat.
      *
      * @description If the SfM computed longitude, latitude exist

--- a/src/graph/ImageCache.ts
+++ b/src/graph/ImageCache.ts
@@ -198,7 +198,7 @@ export class ImageCache {
             return this._cachingAssets$;
         }
 
-        this._cachingAssets$ = observableCombineLatest(
+        const cachingAssets$ = observableCombineLatest(
             this._cacheImage$(spatial),
             this._cacheMesh$(spatial, merged)).pipe(
                 map(
@@ -215,7 +215,9 @@ export class ImageCache {
                 publishReplay(1),
                 refCount());
 
-        this._cachingAssets$.pipe(
+        this._cachingAssets$ = cachingAssets$;
+
+        cachingAssets$.pipe(
             first(
                 (imageCache: ImageCache): boolean => {
                     return !!imageCache._image;
@@ -226,7 +228,7 @@ export class ImageCache {
                 },
                 (): void => { /*noop*/ });
 
-        return this._cachingAssets$;
+        return cachingAssets$;
     }
 
     /**

--- a/src/viewer/Navigator.ts
+++ b/src/viewer/Navigator.ts
@@ -9,6 +9,7 @@ import {
 } from "rxjs";
 
 import {
+    filter as observableFilter,
     finalize,
     first,
     last,
@@ -274,7 +275,13 @@ export class Navigator {
         const cacheImages$ = ids
             .map(
                 (id: string): Observable<Image> => {
-                    return this._graphService.cacheImage$(id);
+                    return this._graphService.hasImage$(id).pipe(
+                        observableFilter((exists: boolean): boolean => {
+                            return exists;
+                        }),
+                        mergeMap((): Observable<Image> => {
+                            return this._graphService.cacheImage$(id);
+                        }));
                 });
 
         return observableFrom(cacheImages$).pipe(
@@ -356,7 +363,7 @@ export class Navigator {
             tap((): void => { if (preCallback) { preCallback(); }; }),
             mergeMap(
                 (): Observable<void> => {
-                    return this._graphService.reset$([]);
+                    return this._graphService.reset$();
                 }));
     }
 

--- a/test/component/spatial/SpatialCache.test.ts
+++ b/test/component/spatial/SpatialCache.test.ts
@@ -518,3 +518,111 @@ describe("SpatialCache.updateReconstructions$", () => {
         resolver(cluster);
     });
 });
+
+describe("SpatialCache.removeCluster", () => {
+    const createCluster = (id: string): ClusterContract => {
+        return {
+            colors: [],
+            coordinates: [],
+            id,
+            pointIds: [],
+            reference: { lat: 0, lng: 0, alt: 0 },
+            rotation: [0, 0, 0]
+        };
+    };
+
+    it("should have cell and cell clusters after remove", () => {
+        const image = new ImageHelper().createImage();
+        const cellId = "123";
+
+        let resolver: Function;
+        const promise: any = {
+            then: (resolve: (value: ClusterContract) => void): void => {
+                resolver = resolve;
+            },
+        };
+
+        const dataProvider = new DataProvider();
+        spyOn(dataProvider, "getCluster").and.returnValue(promise);
+        const graphService = new GraphServiceMockCreator().create();
+        const api = new APIWrapper(dataProvider);
+        const cache = new SpatialCache(graphService, api);
+
+        cacheTile(cellId, cache, graphService, [image]);
+
+        cache.cacheClusters$(cellId).subscribe();
+
+        const cluster = createCluster(image.clusterId);
+        resolver(cluster);
+
+        expect(cache.hasCell(cellId)).toBe(true);
+        expect(cache.hasClusters(cellId)).toBe(true);
+
+        cache.removeCluster(cluster.id);
+
+        expect(cache.hasCell(cellId)).toBe(true);
+        expect(cache.hasClusters(cellId)).toBe(true);
+    });
+
+    it("should remove cluster", () => {
+        const image = new ImageHelper().createImage();
+        const cellId = "123";
+
+        let resolver: Function;
+        const promise: any = {
+            then: (resolve: (value: ClusterContract) => void): void => {
+                resolver = resolve;
+            },
+        };
+
+        const dataProvider = new DataProvider();
+        spyOn(dataProvider, "getCluster").and.returnValue(promise);
+        const graphService = new GraphServiceMockCreator().create();
+        const api = new APIWrapper(dataProvider);
+        const cache = new SpatialCache(graphService, api);
+
+        cacheTile(cellId, cache, graphService, [image]);
+
+        cache.cacheClusters$(cellId).subscribe();
+
+        const cluster = createCluster(image.clusterId);
+        resolver(cluster);
+
+        expect(cache.getClusters(cellId).length).toBe(1);
+
+        cache.removeCluster(cluster.id);
+
+        expect(cache.getClusters(cellId).length).toBe(0);
+    });
+
+    it("should remove images", () => {
+        const image = new ImageHelper().createImage();
+        const cellId = "123";
+
+        let resolver: Function;
+        const promise: any = {
+            then: (resolve: (value: ClusterContract) => void): void => {
+                resolver = resolve;
+            },
+        };
+
+        const dataProvider = new DataProvider();
+        spyOn(dataProvider, "getCluster").and.returnValue(promise);
+        const graphService = new GraphServiceMockCreator().create();
+        const api = new APIWrapper(dataProvider);
+        const cache = new SpatialCache(graphService, api);
+
+        cacheTile(cellId, cache, graphService, [image]);
+
+        cache.cacheClusters$(cellId).subscribe();
+
+        const cluster = createCluster(image.clusterId);
+        resolver(cluster);
+
+        expect(cache.getCell(cellId).length).toBe(1);
+
+        cache.removeCluster(cluster.id);
+
+        expect(cache.getCell(cellId).length).toBe(0);
+    });
+});

--- a/test/helper/GraphServiceMockCreator.ts
+++ b/test/helper/GraphServiceMockCreator.ts
@@ -12,6 +12,7 @@ export class GraphServiceMockCreator extends MockCreatorBase<GraphService> {
         const mock: GraphService = new MockCreator().create(GraphService, "GraphService");
 
         this._mockProperty(mock, "dataAdded$", new Subject<string>());
+        this._mockProperty(mock, "dataDeleted$", new Subject<string>());
         this._mockProperty(mock, "dataReset$", new Subject<void>());
         this._mockProperty(mock, "graphMode$", new Subject<GraphMode>());
         this._mockProperty(mock, "filter$", new Subject<FilterFunction>());

--- a/test/viewer/Navigator.test.ts
+++ b/test/viewer/Navigator.test.ts
@@ -7,6 +7,7 @@ import {
     throwError as observableThrowError,
     Observable,
     Subject,
+    BehaviorSubject,
 } from "rxjs";
 import { first } from "rxjs/operators";
 
@@ -592,6 +593,9 @@ describe("Navigator.setFilter$", () => {
                 return cacheImageSubject2$;
             });
 
+        const hasImageSubject = new Subject<boolean>();
+        const hasImageSpy = spyOn(graphService, "hasImage$").and.returnValue(hasImageSubject);
+
         const navigator: Navigator =
             new Navigator(
                 { container: "co" },
@@ -640,6 +644,8 @@ describe("Navigator.setFilter$", () => {
         currentStateSubject$.complete();
         setFilterSubject$.next(graph);
         setFilterSubject$.complete();
+        hasImageSubject.next(true);
+        hasImageSubject.complete();
         cacheImageSubject2$.next(image1);
         cacheImageSubject2$.next(image2);
         cacheImageSubject2$.complete();
@@ -691,8 +697,7 @@ describe("Navigator.setToken$", () => {
                     expect(setTokenSpy.calls.first().args[0]).toBe("token");
 
                     expect(resetSpy.calls.count()).toBe(1);
-                    expect(resetSpy.calls.first().args.length).toBe(1);
-                    expect(resetSpy.calls.first().args[0]).toEqual([]);
+                    expect(resetSpy.calls.first().args.length).toBe(0);
 
                     done();
                 });
@@ -777,8 +782,7 @@ describe("Navigator.setToken$", () => {
                     expect(setTokenSpy.calls.first().args[0]).toBe("token");
 
                     expect(resetSpy.calls.count()).toBe(1);
-                    expect(resetSpy.calls.first().args.length).toBe(1);
-                    expect(resetSpy.calls.first().args[0].length).toBe(0);
+                    expect(resetSpy.calls.first().args.length).toBe(0);
 
                     done();
                 });


### PR DESCRIPTION
Handle deletion in graph.
Remove cluster from spatial on delete.
Unit tests.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Makes it possible to delete clusters from the viewer through a data provider API.

## Contribution

- Add event that a data provider can emit to notify that a cluster has been deleted.
- Add example pages for using the API.
- Unit  test.

## Test Plan

```
yarn prepare
yarn test
yarn start
```
