### PR TITLE
Make panning stable for highly distorted cameras

### DIFF
--- a/src/geometry/camera/FisheyeCamera.ts
+++ b/src/geometry/camera/FisheyeCamera.ts
@@ -90,6 +90,10 @@ vec2 projectToSfm(vec3 bearing, Parameters parameters, Uniforms uniforms) {
     float radialPeak = uniforms.radialPeak;
 
     // Projection
+    if (z < 0.) {
+        return vec2(POSITIVE_INFINITY, POSITIVE_INFINITY);
+    }
+
     float r = sqrt(x * x + y * y);
     float theta = atan(r, z);
 

--- a/src/render/RenderCamera.ts
+++ b/src/render/RenderCamera.ts
@@ -419,11 +419,11 @@ export class RenderCamera {
     }
 
     private _computeProjectedPoints(transform: Transform): number[][] {
-        const vertices = [[0, 0], [1, 0]];
-        const directions = [[1, 0], [0, 1]];
-        const pointsPerLine = 50;
+        const vertices = [[0.5, 0], [0.5, 0], [1, 0.5], [1, 0.5]];
+        const directions = [[-0.5, 0], [0.5, 0], [0, -0.5], [0, 0.5]];
+        const pointsPerLine = 25;
 
-        return Geo.computeProjectedPoints(
+        return Geo.computeProjectedPointsSafe(
             transform,
             vertices,
             directions,
@@ -475,7 +475,9 @@ export class RenderCamera {
                         aspect);
                 });
 
-        const vFovFill = Math.min(...fovs) * 0.995;
+        const fovMax = 125;
+        const minFov = Math.min(...fovs) * 0.995;
+        const vFovFill = Math.min(minFov, fovMax);
         if (renderMode === RenderMode.Fill) {
             return vFovFill;
         }
@@ -492,7 +494,6 @@ export class RenderCamera {
             vFov *= hFovMax / hFovLetterbox;
         }
 
-        const fovMax = 135;
         const vFovMax = aspect > 2 ? vFovFill : fovCoeff * vFovFill;
         vFov = Math.min(vFov, vFovMax, fovMax);
         vFov = Math.max(vFov, vFovFill);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Ensure that heavily distorted imagery can be panned in a stable way.

## Contribution

- Add function to safely compute projected points. Stop the iteration when first projected point is behind camera.
- Set a max fov to avoid stability issues.

## Test Plan

```
yarn test
yarn build
yarn start
```
