### PR TITLE
Clear spatial edges after cells have been updated

### DIFF
--- a/src/graph/GraphService.ts
+++ b/src/graph/GraphService.ts
@@ -20,6 +20,7 @@ import {
     startWith,
     tap,
     takeLast,
+    withLatestFrom,
 } from "rxjs/operators";
 
 import { FilterFunction } from "./FilterCreator";
@@ -656,11 +657,15 @@ export class GraphService {
                 first(),
                 mergeMap(
                     graph => {
+                        return graph.updateCells$(event.cellIds);
+                    }),
+                withLatestFrom(this._graph$.pipe(first())),
+                tap(
+                    ([_, graph]) => {
                         graph.resetSpatialArea();
                         graph.resetSpatialEdges();
-                        return graph.updateCells$(event.cellIds);
                     }))
-            .subscribe(cellId => { this._dataAdded$.next(cellId); });
+            .subscribe(([cellId]) => { this._dataAdded$.next(cellId); });
     };
 
     private _onDataDeleted = (event: ProviderClusterEvent): void => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Do not clear spatial edges if the added data did not actually update a cell.

## Contribution

- Graph is reset after a cell has been updated but before data added event is sent.

## Test Plan

```
yarn test
yarn start
```
