### PR TITLE
Do not require cluster id to exist for image

### DIFF
--- a/src/graph/Graph.ts
+++ b/src/graph/Graph.ts
@@ -1910,7 +1910,8 @@ export class Graph {
     private _addClusterNode(node: Image): void {
         const clusterId = node.clusterId;
         if (clusterId == null) {
-            throw new GraphMapillaryError(`Image does not have cluster (${node.id}).`);
+            console.warn(`Cannot set cluster node, cluster ID is undefined for node ${node.id}.`);
+            return;
         }
 
         if (!this._clusterNodes.has(clusterId)) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Cluster may be missing, do not throw fatal error but be more resilient.

## Contribution

- Warn instead of throwing when cluster is not set on image.

## Test Plan

```
yarn test
yarn start
```
