### PR TITLE
Use empty array if camera params not set

### DIFF
--- a/src/api/provider/GraphConverter.ts
+++ b/src/api/provider/GraphConverter.ts
@@ -151,6 +151,7 @@ export class GraphConverter {
         source: GraphSpatialImageEnt)
         : SpatialImageEnt {
         source.camera_type = convertCameraType(source.camera_type);
+        source.camera_parameters = source.camera_parameters ?? [];
         source.merge_id = source.merge_cc ? source.merge_cc.toString() : null;
         source.private = null;
         const thumbUrl = source.camera_type === 'spherical' ?


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Contribution

- Fall back to empty array if camera parameters are unset to avoid errors downstream.

## Test Plan

```
yarn test
yarn build
```
