### PR TITLE
Treat gravity and street states equally

### DIFF
--- a/src/component/image/ImageComponent.ts
+++ b/src/component/image/ImageComponent.ts
@@ -260,6 +260,7 @@ export class ImageComponent extends Component<ComponentConfiguration> {
                 switchMap(
                     ([state, inTranslation]: [State, boolean]) => {
                         const streetState =
+                            state === State.GravityTraversing ||
                             state === State.Traversing ||
                             state === State.Waiting ||
                             state === State.WaitingInteractively;

--- a/src/tile/TextureProvider.ts
+++ b/src/tile/TextureProvider.ts
@@ -383,7 +383,8 @@ export class TextureProvider {
             },
             (error: Error): void => {
                 this._urlSubscriptions.delete(level);
-                console.error(error);
+                // tslint:disable-next-line:no-console
+                console.debug(error);
             });
 
         if (!subscription.closed) {

--- a/src/viewer/Observer.ts
+++ b/src/viewer/Observer.ts
@@ -365,7 +365,8 @@ export class Observer {
                                 reference,
                                 transform);
 
-                        const basicPoint = state === State.Traversing ?
+                        const basicPoint = state === State.Traversing ||
+                            state === State.GravityTraversing ?
                             unprojection.basicPoint : null;
 
                         return {


### PR DESCRIPTION
Perform image tiling for gravity state.
Log image tiling errors with verbose flag to avoid spamming.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Contribution

- Treat gravity and street states equally to ensure that image tiling and projection works in both cases.

## Test Plan

```
yarn start
```
