### PR TITLE
Track failed image tile levels

### DIFF
--- a/src/tile/TileLoader.ts
+++ b/src/tile/TileLoader.ts
@@ -7,6 +7,7 @@ import {
     map,
     publish,
     refCount,
+    retry,
 } from "rxjs/operators";
 import { APIWrapper } from "../api/APIWrapper";
 import { ImageTileEnt } from "../api/ents/ImageTileEnt";
@@ -96,6 +97,7 @@ export class TileLoader {
         const urls$ = this._api
             .getImageTiles$(request)
             .pipe(
+                retry(1),
                 map(contract => contract.node),
                 finalize(
                     () => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Track failed tile levels to avoid repeating the same request multiple times.

## Contribution

- Retry tile level API request once on error to be more resilient.

## Test Plan

```
yarn build
yarn test
yarn start
```
