### PR TITLE
Add transparent render pass for custom renderers

### DIFF
--- a/declarations/mapillary.js.flow
+++ b/declarations/mapillary.js.flow
@@ -3113,6 +3113,7 @@ export type ViewerEventType =
 
 declare var RenderPass: {|
   +Opaque: 0, // 0
+  +Transparent: 1, // 1
 |};
 
 /**

--- a/src/render/GLRenderer.ts
+++ b/src/render/GLRenderer.ts
@@ -106,6 +106,7 @@ export class GLRenderer {
     private _subscriptions: SubscriptionHolder = new SubscriptionHolder();
 
     private _opaqueRender$: Subject<void> = new Subject<void>();
+    private _transparentRender$: Subject<void> = new Subject<void>();
 
     constructor(
         canvas: HTMLCanvasElement,
@@ -245,6 +246,7 @@ export class GLRenderer {
                     renderer.resetState();
 
                     this._opaqueRender$.next();
+                    this._transparentRender$.next();
                 });
 
         subs.push(renderSubscription);
@@ -396,6 +398,10 @@ export class GLRenderer {
 
     public get opaqueRender$(): Observable<void> {
         return this._opaqueRender$;
+    }
+
+    public get transparentRender$(): Observable<void> {
+        return this._transparentRender$;
     }
 
     public get webGLRenderer$(): Observable<THREE.WebGLRenderer> {

--- a/src/viewer/CustomRenderer.ts
+++ b/src/viewer/CustomRenderer.ts
@@ -13,6 +13,7 @@ import { LngLatAlt } from "../api/interfaces/LngLatAlt";
 import { WebGLRenderer } from "three";
 import { RenderCamera } from "../render/RenderCamera";
 import { IViewer } from "./interfaces/IViewer";
+import { RenderPass } from "./enums/RenderPass";
 
 export class CustomRenderer {
     private _renderers: {
@@ -44,7 +45,11 @@ export class CustomRenderer {
                     renderer.onAdd(viewer, reference, gl.getContext());
                 }));
 
-        subs.push(this._container.glRenderer.opaqueRender$
+        const render$ = renderer.renderPass === RenderPass.Opaque ?
+            this._container.glRenderer.opaqueRender$ :
+            this._container.glRenderer.transparentRender$;
+
+        subs.push(render$
             .pipe(
                 withLatestFrom(
                     this._container.renderService.renderCamera$,

--- a/src/viewer/enums/RenderPass.ts
+++ b/src/viewer/enums/RenderPass.ts
@@ -3,4 +3,9 @@ export enum RenderPass {
      * Occurs after the background render pass.
      */
     Opaque,
+
+    /**
+     * Occurs last in the render sequence, after the opaque render pass.
+     */
+    Transparent,
 }

--- a/test/helper/GLRendererMockCreator.ts
+++ b/test/helper/GLRendererMockCreator.ts
@@ -12,6 +12,7 @@ export class GLRendererMockCreator extends MockCreatorBase<GLRenderer> {
         this._mockProperty(mock, "webGLRenderer$", new Subject<THREE.WebGLRenderer>());
         this._mockProperty(mock, "render$", new Subject<GLRenderHash>());
         this._mockProperty(mock, "opaqueRender$", new Subject<void>());
+        this._mockProperty(mock, "transparentRender$", new Subject<void>());
 
         return mock;
     }


### PR DESCRIPTION
Render transparently after opaque pass.

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Make it possible to decide what pass to render in for custom renderers.

## Contribution

- Add transparent render pass option for custom renderers.

## Test Plan

```
yarn build
yarn test
yarn start
```
