### PR TITLE
Handle spatial edges for graph resets

### DIFF
--- a/doc/src/js/utils/provider.js
+++ b/doc/src/js/utils/provider.js
@@ -59,7 +59,7 @@ export function generateCluster(options, intervals) {
   let {idCounter} = options;
   const {alt, lat, lng} = options.reference;
 
-  const distance = 5;
+  const distance = options.distance ?? 5;
 
   const images = [];
   const thumbUrl = `${cameraType}`;

--- a/examples/debug/chunk.html
+++ b/examples/debug/chunk.html
@@ -61,6 +61,7 @@
                     dataProvider,
                     cameraControls: CameraControls.Earth,
                     component: {
+                        cache: false,
                         cover: false,
                         image: false,
                         spatial: {
@@ -73,6 +74,7 @@
                     imageTiling: false,
                 };
                 viewer = new Viewer(options);
+                viewer.setFilter(['!=', 'cameraType', 'invalid'])
                 chunks = [];
 
                 listen();
@@ -81,13 +83,15 @@
             function generateChunk() {
                 const cameraType = CAMERA_TYPE_SPHERICAL;
                 const aspect = cameraTypeToAspect(cameraType);
+                const distance = 1;
                 const height = 100;
                 const counter = chunks.length;
-                const shift = counter * 10;
+                const shift = counter * 1;
                 const mod = 3;
                 const config = {
                     cameraType,
                     color: [1, (counter % mod) / (mod - 1), 0],
+                    distance,
                     east: shift,
                     height,
                     id: counter.toString(),

--- a/src/graph/GraphService.ts
+++ b/src/graph/GraphService.ts
@@ -37,6 +37,7 @@ import { GraphMapillaryError } from "../error/GraphMapillaryError";
 import { ProjectionService } from "../viewer/ProjectionService";
 import { ICameraFactory } from "../geometry/interfaces/ICameraFactory";
 import { ProviderClusterEvent } from "../api/events/ProviderClusterEvent";
+import { CancelMapillaryError } from "../error/CancelMapillaryError";
 
 /**
  * @class GraphService
@@ -386,7 +387,12 @@ export class GraphService {
                                     return graph$.pipe(
                                         catchError(
                                             (error: Error): Observable<Graph> => {
-                                                console.error(`Failed to cache spatial images (${id}).`, error);
+                                                if (error instanceof CancelMapillaryError) {
+                                                    // tslint:disable-next-line:no-console
+                                                    console.debug(`Failed to cache spatial area (${id}).`, error);
+                                                } else {
+                                                    console.error(`Failed to cache spatial area (${id}).`, error);
+                                                }
 
                                                 return observableEmpty();
                                             }));


### PR DESCRIPTION
## Motivation

When the spatial edges are reset there should not be console errors and the latest data should be used for the edge calculation.

## Contribution

- Prioritize the latest graph area request. 
- Cancel prior requests.

## Test Plan

```
yarn build
yarn test
yarn start
```

Navigate to `chunk` example.
