### PR TITLE
Use bearings for field of view visualization

### DIFF
--- a/src/geo/Spatial.ts
+++ b/src/geo/Spatial.ts
@@ -230,6 +230,24 @@ export class Spatial {
         return Math.asin(projection / norm);
     }
 
+    /**
+     * Calculates the projection of a vector onto a plane.
+     *
+     * @param {Array<number>} vector - The vector.
+     * @param {Array<number>} planeNormal - Normal of the plane.
+     * @returns {number} Projection of vector onto plane.
+     */
+    public projectToPlane(vector: number[], planeNormal: number[]): number[] {
+        const directionVector: THREE.Vector3 = new THREE.Vector3().fromArray(vector);
+        const normalVector: THREE.Vector3 = new THREE.Vector3().fromArray(planeNormal);
+
+        const normalProjection: number = directionVector.clone().dot(normalVector);
+        const planeProjection: THREE.Vector3 = directionVector
+            .clone().sub(normalVector.clone().multiplyScalar(normalProjection));
+
+        return planeProjection.toArray();
+    }
+
     public azimuthal(direction: number[], up: number[]): number {
         const directionVector: THREE.Vector3 = new THREE.Vector3().fromArray(direction);
         const upVector: THREE.Vector3 = new THREE.Vector3().fromArray(up);


### PR DESCRIPTION
## Motivation

Support fields of view larger than 180 degrees.

## Contribution

Use bearings instead of projected points to calculate field of view.

## Test Plan

```
yarn build
yarn test
yarn start
```
