### PR TITLE
Use bearings in field of view handling

### DIFF
--- a/examples/debug/fisheye.html
+++ b/examples/debug/fisheye.html
@@ -91,7 +91,7 @@
 
             function generateChunk() {
                 const cameraType = CAMERA_TYPE_FISHEYE;
-                const height = 2495;
+                const height = 2496;
                 const width = 2496;
                 const focal = 0.2212;
                 const k1 = 0.1282;

--- a/src/component/bearing/BearingComponent.ts
+++ b/src/component/bearing/BearingComponent.ts
@@ -473,9 +473,9 @@ export class BearingComponent extends Component<BearingConfiguration> {
             transform, vertices, directions, pointsPerLine, this._viewportCoords);
         const projections = bearings
             .map(b => this._spatial.projectToPlane(b, [0, 1, 0]))
-            .map(p => [p[0], p[2]]);
+            .map(p => [p[0], -p[2]]);
 
-        const angles = projections.map(p => Math.atan2(p[0], -p[1]));
+        const angles = projections.map(p => Math.abs(Math.atan2(p[0], p[1])));
         const fov = 2 * Math.min(...angles);
 
         return fov;

--- a/src/geo/Geo.ts
+++ b/src/geo/Geo.ts
@@ -43,8 +43,23 @@ export function computeBearings(
     camera.up.copy(transform.upVector());
     camera.position.copy(new THREE.Vector3().fromArray(transform.unprojectSfM([0, 0], 0)));
     camera.lookAt(new THREE.Vector3().fromArray(transform.unprojectSfM([0, 0], 10)));
-    camera.updateMatrix();
-    camera.updateMatrixWorld(true);
+
+    return computeCameraBearings(
+        camera,
+        transform,
+        basicVertices,
+        basicDirections,
+        pointsPerLine,
+        viewportCoords);
+}
+
+export function computeCameraBearings(
+    camera: THREE.Camera,
+    transform: Transform,
+    basicVertices: number[][],
+    basicDirections: number[][],
+    pointsPerLine: number,
+    viewportCoords: ViewportCoords): number[][] {
 
     const basicPoints: number[][] = [];
     for (let side: number = 0; side < basicVertices.length; ++side) {
@@ -59,8 +74,10 @@ export function computeBearings(
         }
     }
 
+    camera.updateMatrix();
+    camera.updateMatrixWorld(true);
     const bearings: number[][] = [];
-    for (const [index, basicPoint] of basicPoints.entries()) {
+    for (const basicPoint of basicPoints) {
         const worldPoint = transform.unprojectBasic(basicPoint, 10000);
         const cameraPoint = new THREE.Vector3()
             .fromArray(viewportCoords.worldToCamera(worldPoint, camera));

--- a/src/render/RenderCamera.ts
+++ b/src/render/RenderCamera.ts
@@ -475,7 +475,7 @@ export class RenderCamera {
                         aspect);
                 });
 
-        const fovMax = 125;
+        const fovMax = this._yToFov(this._fovToY(125, 0), zoom);
         const minFov = Math.min(...fovs) * 0.995;
         const vFovFill = Math.min(minFov, fovMax);
         if (renderMode === RenderMode.Fill) {

--- a/test/render/RenderCamera.test.ts
+++ b/test/render/RenderCamera.test.ts
@@ -155,12 +155,15 @@ describe("RenderCamera.perspective.fov", () => {
 
     it("should increase when changing from fill to letterbox", () => {
         const renderCamera = new RenderCamera(1, 1, RenderMode.Fill);
+        console.error(renderCamera.perspective.fov);
+        const frame = new FrameHelper().createFrame();
+        console.error(frame);
         renderCamera.setFrame(new FrameHelper().createFrame());
         const fov = renderCamera.perspective.fov;
 
         renderCamera.setRenderMode(RenderMode.Letterbox);
 
-        expect(renderCamera.perspective.fov).toBeGreaterThan(fov);
+        expect(renderCamera.perspective.fov).toBeGreaterThanOrEqual(fov);
     });
 
     it("should decrease when increasing aspect", () => {
@@ -170,7 +173,7 @@ describe("RenderCamera.perspective.fov", () => {
 
         renderCamera.setSize({ width: 5, height: 1 });
 
-        expect(renderCamera.perspective.fov).toBeLessThan(fov);
+        expect(renderCamera.perspective.fov).toBeLessThanOrEqual(fov);
     });
 
     it("should be constant when decreasing aspect", () => {


### PR DESCRIPTION
## Motivation

Ensure that cameras with a >180 degree field of view are handled correctly.

## Contribution

- Use bearings to determine field of view for render camera.
- Use bearings to determine field of view for pan images.
- Apply zoom to max field of view calculation.

## Test Plan

```
yarn build
yarn test
yarn start
```

```
localhost:8000/tag.html
localhost:8000/fisheye.html
```
