### PR TITLE
Use geometry to avoid reference reset

### DIFF
--- a/src/state/StateContext.ts
+++ b/src/state/StateContext.ts
@@ -9,6 +9,7 @@ import { Transform } from "../geo/Transform";
 import { LngLatAlt } from "../api/interfaces/LngLatAlt";
 import { Image } from "../graph/Image";
 import { StateTransitionMatrix } from "./StateTransitionMatrix";
+import { IGeometryProvider } from "../api/interfaces/IGeometryProvider";
 
 export class StateContext implements IStateContext {
     private _state: StateBase;
@@ -16,6 +17,7 @@ export class StateContext implements IStateContext {
 
     constructor(
         state: State,
+        geometry: IGeometryProvider,
         transitionMode?: TransitionMode) {
         this._transitions = new StateTransitionMatrix();
         this._state = this._transitions.generate(
@@ -24,6 +26,7 @@ export class StateContext implements IStateContext {
                 alpha: 1,
                 camera: new Camera(),
                 currentIndex: -1,
+                geometry,
                 reference: { alt: 0, lat: 0, lng: 0 },
                 trajectory: [],
                 transitionMode: transitionMode == null ? TransitionMode.Default : transitionMode,

--- a/src/state/StateService.ts
+++ b/src/state/StateService.ts
@@ -33,6 +33,7 @@ import { Transform } from "../geo/Transform";
 import { LngLatAlt } from "../api/interfaces/LngLatAlt";
 import { SubscriptionHolder } from "../util/SubscriptionHolder";
 import { Clock } from "three";
+import { IGeometryProvider } from "../api/interfaces/IGeometryProvider";
 
 interface IContextOperation {
     (context: IStateContext): IStateContext;
@@ -73,6 +74,7 @@ export class StateService {
 
     constructor(
         initialState: State,
+        geometry: IGeometryProvider,
         transitionMode?: TransitionMode) {
 
         const subs = this._subscriptions;
@@ -90,7 +92,7 @@ export class StateService {
                 (context: IStateContext, operation: IContextOperation): IStateContext => {
                     return operation(context);
                 },
-                new StateContext(initialState, transitionMode)),
+                new StateContext(initialState, geometry, transitionMode)),
             publishReplay(1),
             refCount());
 

--- a/src/state/interfaces/IStateBase.ts
+++ b/src/state/interfaces/IStateBase.ts
@@ -2,11 +2,13 @@ import { Camera } from "../../geo/Camera";
 import { LngLatAlt } from "../../api/interfaces/LngLatAlt";
 import { TransitionMode } from "../TransitionMode";
 import { Image } from "../../graph/Image";
+import { IGeometryProvider } from "../../mapillary";
 
 export interface IStateBase {
     alpha: number;
     camera: Camera;
     currentIndex: number;
+    geometry: IGeometryProvider,
     reference: LngLatAlt;
     trajectory: Image[];
     transitionMode: TransitionMode;

--- a/src/viewer/Navigator.ts
+++ b/src/viewer/Navigator.ts
@@ -95,6 +95,7 @@ export class Navigator {
         this._stateService = stateService ??
             new StateService(
                 cameraControlsToState(cameraControls),
+                this._api.data.geometry,
                 options.transitionMode);
 
         this._cacheService = cacheService ??

--- a/test/helper/StateHelper.ts
+++ b/test/helper/StateHelper.ts
@@ -1,3 +1,4 @@
+import { S2GeometryProvider } from "../../src/api/S2GeometryProvider";
 import { Camera } from "../../src/geo/Camera";
 import { IAnimationState } from "../../src/state/interfaces/IAnimationState";
 import { IStateBase } from "../../src/state/interfaces/IStateBase";
@@ -31,6 +32,7 @@ export function generateStateParams(): IStateBase {
         alpha: 1,
         camera: new Camera(),
         currentIndex: -1,
+        geometry: new S2GeometryProvider(),
         reference: { alt: 0, lat: 0, lng: 0 },
         trajectory: [],
         transitionMode: TransitionMode.Default,

--- a/test/state/StateService.test.ts
+++ b/test/state/StateService.test.ts
@@ -3,10 +3,11 @@ bootstrap();
 
 import { StateService } from "../../src/state/StateService";
 import { State } from "../../src/state/State";
+import { S2GeometryProvider } from "../../src/api/S2GeometryProvider";
 
 describe("StateService.ctor", () => {
     it("should be contructed", () => {
-        let stateService: StateService = new StateService(State.Traversing);
+        let stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         expect(stateService).toBeDefined();
     });

--- a/test/state/state/StateBase.test.ts
+++ b/test/state/state/StateBase.test.ts
@@ -12,6 +12,7 @@ import { ProjectionService } from "../../../src/viewer/ProjectionService";
 import { ImageCache } from "../../../src/graph/ImageCache";
 import { DataProvider } from "../../helper/ProviderHelper";
 import { TestImage } from "../../helper/TestImage";
+import { S2GeometryProvider } from "../../../src/api/S2GeometryProvider";
 
 class TestStateBase extends StateBase {
     public traverse(): StateBase { return null; }
@@ -42,6 +43,7 @@ let createState: () => IStateBase = (): IStateBase => {
         alpha: 1,
         camera: new Camera(),
         currentIndex: -1,
+        geometry: new S2GeometryProvider(),
         reference: { alt: 0, lat: 0, lng: 0 },
         trajectory: [],
         transitionMode: TransitionMode.Default,

--- a/test/state/state/TraversingState.test.ts
+++ b/test/state/state/TraversingState.test.ts
@@ -14,6 +14,7 @@ import { ImageCache } from "../../../src/graph/ImageCache";
 import { DataProvider } from "../../helper/ProviderHelper";
 import { ProjectionService } from "../../../src/viewer/ProjectionService";
 import { TestImage } from "../../helper/TestImage";
+import { S2GeometryProvider } from "../../../src/api/S2GeometryProvider";
 
 describe("TraversingState.ctor", () => {
     it("should be defined", () => {
@@ -21,6 +22,7 @@ describe("TraversingState.ctor", () => {
             alpha: 1,
             camera: new Camera(),
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -72,6 +74,7 @@ describe("TraversingState.currentCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -106,6 +109,7 @@ describe("TraversingState.currentCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -148,6 +152,7 @@ describe("TraversingState.currentCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -204,6 +209,7 @@ describe("TraversingState.previousCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -238,6 +244,7 @@ describe("TraversingState.previousCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,

--- a/test/state/state/WaitingState.test.ts
+++ b/test/state/state/WaitingState.test.ts
@@ -2,7 +2,6 @@ import * as THREE from "three";
 
 import { ImageHelper } from "../../helper/ImageHelper";
 
-import { Image } from "../../../src/graph/Image";
 import { SpatialImageEnt } from "../../../src/api/ents/SpatialImageEnt";
 import { IStateBase } from "../../../src/state/interfaces/IStateBase";
 import { WaitingState } from "../../../src/state/state/WaitingState";
@@ -12,6 +11,7 @@ import { ImageCache } from "../../../src/graph/ImageCache";
 import { DataProvider } from "../../helper/ProviderHelper";
 import { ProjectionService } from "../../../src/viewer/ProjectionService";
 import { TestImage } from "../../helper/TestImage";
+import { S2GeometryProvider } from "../../../src/api/S2GeometryProvider";
 
 describe("WaitingState.ctor", () => {
     it("should be defined", () => {
@@ -19,6 +19,7 @@ describe("WaitingState.ctor", () => {
             alpha: 1,
             camera: new Camera(),
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -70,6 +71,7 @@ describe("WaitingState.currentCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -104,6 +106,7 @@ describe("WaitingState.currentCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -146,6 +149,7 @@ describe("WaitingState.currentCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -205,6 +209,7 @@ describe("WaitingState.previousCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -239,6 +244,7 @@ describe("WaitingState.previousCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,
@@ -279,6 +285,7 @@ describe("WaitingState.previousCamera.lookat", () => {
             alpha: 1,
             camera: camera,
             currentIndex: -1,
+            geometry: new S2GeometryProvider(),
             reference: { alt: 0, lat: 0, lng: 0 },
             trajectory: [],
             transitionMode: TransitionMode.Default,

--- a/test/viewer/CacheService.test.ts
+++ b/test/viewer/CacheService.test.ts
@@ -10,7 +10,6 @@ import { APIWrapper } from "../../src/api/APIWrapper";
 import { Graph } from "../../src/graph/Graph";
 import { GraphMode } from "../../src/graph/GraphMode";
 import { GraphService } from "../../src/graph/GraphService";
-import { IAnimationState } from "../../src/state/interfaces/IAnimationState";
 import { AnimationFrame } from "../../src/state/interfaces/AnimationFrame";
 import { State } from "../../src/state/State";
 import { StateService } from "../../src/state/StateService";
@@ -18,13 +17,14 @@ import { CacheService } from "../../src/viewer/CacheService";
 import { DataProvider } from "../helper/ProviderHelper";
 import { createDefaultState } from "../helper/StateHelper";
 import { StateServiceMockCreator } from "../helper/StateServiceMockCreator";
-import { LngLatAlt } from "../../src/mapillary";
+import { S2GeometryProvider } from "../../src/api/S2GeometryProvider";
+import { LngLatAlt } from "../../src/api/interfaces/LngLatAlt";
 
 describe("CacheService.ctor", () => {
     it("should be defined when constructed", () => {
         const api = new APIWrapper(new DataProvider());
         const graphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const cacheService = new CacheService(graphService, stateService, api);
 
@@ -36,7 +36,7 @@ describe("CacheService.configure", () => {
     it("should configure without errors", () => {
         const api = new APIWrapper(new DataProvider());
         const graphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const cacheService = new CacheService(graphService, stateService, api);
 
@@ -50,7 +50,7 @@ describe("CacheService.started", () => {
     it("should not be started", () => {
         const api = new APIWrapper(new DataProvider());
         const graphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const cacheService = new CacheService(graphService, stateService, api);
 
@@ -60,7 +60,7 @@ describe("CacheService.started", () => {
     it("should be started after calling start", () => {
         const api = new APIWrapper(new DataProvider());
         const graphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const cacheService = new CacheService(graphService, stateService, api);
 
@@ -72,7 +72,7 @@ describe("CacheService.started", () => {
     it("should not be started after calling stop", () => {
         const api = new APIWrapper(new DataProvider());
         const graphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const cacheService = new CacheService(graphService, stateService, api);
 
@@ -87,7 +87,7 @@ class TestStateService extends StateService {
     private _overridingCurrentState$: Subject<AnimationFrame>;
 
     constructor(currentState$: Subject<AnimationFrame>) {
-        super(State.Traversing);
+        super(State.Traversing, new S2GeometryProvider());
 
         this._overridingCurrentState$ = currentState$;
     }

--- a/test/viewer/Navigator.test.ts
+++ b/test/viewer/Navigator.test.ts
@@ -30,6 +30,7 @@ import { CancelMapillaryError } from "../../src/error/CancelMapillaryError";
 import { NavigationDirection } from "../../src/graph/edge/NavigationDirection";
 import { DataProvider } from "../helper/ProviderHelper";
 import * as Common from "../../src/util/Common";
+import { S2GeometryProvider } from "../../src/api/S2GeometryProvider";
 
 const createState: () => IAnimationState = (): IAnimationState => {
     return {
@@ -66,7 +67,7 @@ describe("Navigator.ctor", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const navigator: Navigator =
@@ -87,7 +88,7 @@ describe("Navigator.moveToKey$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const loadingSpy: jasmine.Spy = spyOn(loadingService, "startLoading").and.stub();
@@ -115,7 +116,7 @@ describe("Navigator.moveToKey$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         spyOn(loadingService, "startLoading").and.stub();
         const stopLoadingSpy: jasmine.Spy = spyOn(loadingService, "stopLoading").and.stub();
@@ -152,7 +153,7 @@ describe("Navigator.moveToKey$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
@@ -188,7 +189,7 @@ describe("Navigator.moveToKey$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
@@ -220,7 +221,7 @@ describe("Navigator.moveToKey$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         spyOn(loadingService, "startLoading").and.stub();
         spyOn(loadingService, "stopLoading").and.stub();
@@ -257,7 +258,7 @@ describe("Navigator.moveToKey$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         spyOn(loadingService, "startLoading").and.stub();
         spyOn(loadingService, "stopLoading").and.stub();
@@ -298,7 +299,7 @@ describe("Navigator.moveToKey$", () => {
             const api: APIWrapper = new APIWrapper(new DataProvider());
             const graphService: GraphService = new GraphService(new Graph(api));
             const loadingService: LoadingService = new LoadingService();
-            const stateService: StateService = new StateService(State.Traversing);
+            const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
             const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
             spyOn(loadingService, "startLoading").and.stub();
@@ -357,7 +358,7 @@ describe("Navigator.movedToKey$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
@@ -404,7 +405,7 @@ class TestStateService extends StateService {
     private _overridingCurrentState$: Subject<AnimationFrame>;
 
     constructor(currentState$: Subject<AnimationFrame>) {
-        super(State.Traversing);
+        super(State.Traversing, new S2GeometryProvider());
 
         this._overridingCurrentState$ = currentState$;
     }
@@ -426,7 +427,7 @@ describe("Navigator.setFilter$", () => {
         const graph: Graph = new Graph(api);
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const clearImagesSpy: jasmine.Spy = spyOn(stateService, "clearImages").and.stub();
@@ -468,7 +469,7 @@ describe("Navigator.setFilter$", () => {
         const graph: Graph = new Graph(api);
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         const setFilterSpy: jasmine.Spy = spyOn(graphService, "setFilter$");
@@ -500,7 +501,7 @@ describe("Navigator.setFilter$", () => {
         const graph: Graph = new Graph(api);
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();
@@ -667,7 +668,7 @@ describe("Navigator.setToken$", () => {
         const graph: Graph = new Graph(api);
         const graphService: GraphService = new GraphService(graph);
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(cacheService, "start").and.stub();
@@ -798,7 +799,7 @@ describe("Navigator.setToken$", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
         const loadingService: LoadingService = new LoadingService();
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
         const cacheService: CacheService = new CacheService(graphService, stateService, api);
 
         spyOn(loadingService, "startLoading").and.stub();

--- a/test/viewer/PlayService.test.ts
+++ b/test/viewer/PlayService.test.ts
@@ -28,12 +28,13 @@ import { StateService } from "../../src/state/StateService";
 import { PlayService } from "../../src/viewer/PlayService";
 import { NavigationDirection } from "../../src/graph/edge/NavigationDirection";
 import { DataProvider } from "../helper/ProviderHelper";
+import { S2GeometryProvider } from "../../src/api/S2GeometryProvider";
 
 describe("PlayService.ctor", () => {
     it("should be defined when constructed", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const playService: PlayService = new PlayService(graphService, stateService);
 
@@ -43,7 +44,7 @@ describe("PlayService.ctor", () => {
     it("should emit default values", (done: () => void) => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const playService: PlayService = new PlayService(graphService, stateService);
 
@@ -67,7 +68,7 @@ describe("PlayService.playing", () => {
     it("should be playing after calling play", (done: () => void) => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const playService: PlayService = new PlayService(graphService, stateService);
 
@@ -87,7 +88,7 @@ describe("PlayService.playing", () => {
     it("should not be playing after calling stop", (done: () => void) => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const playService: PlayService = new PlayService(graphService, stateService);
 
@@ -123,7 +124,7 @@ describe("PlayService.speed$", () => {
     it("should emit when changing speed", (done: () => void) => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const playService: PlayService = new PlayService(graphService, stateService);
 
@@ -142,7 +143,7 @@ describe("PlayService.speed$", () => {
     it("should not emit when setting current speed", () => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const playService: PlayService = new PlayService(graphService, stateService);
 
@@ -175,7 +176,7 @@ describe("PlayService.speed$", () => {
     it("should clamp speed values to 0, 1 interval", (done: () => void) => {
         const api: APIWrapper = new APIWrapper(new DataProvider());
         const graphService: GraphService = new GraphService(new Graph(api));
-        const stateService: StateService = new StateService(State.Traversing);
+        const stateService: StateService = new StateService(State.Traversing, new S2GeometryProvider());
 
         const playService: PlayService = new PlayService(graphService, stateService);
 


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

When larger tile sizes for the geometry provider are used the reference should not be reset if it is within the original grid.

## Test Plan

```
yarn prepare
yarn start
```
