### PR TITLE
Zoom in with equal key

### DIFF
--- a/src/component/keyboard/KeyZoomHandler.ts
+++ b/src/component/keyboard/KeyZoomHandler.ts
@@ -57,6 +57,7 @@ export class KeyZoomHandler extends HandlerBase<KeyboardConfiguration> {
                     let delta: number = 0;
                     switch (event.key) {
                         case "+":
+                        case "=":
                             delta = 1;
                             break;
                         case "-":


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Adhere to 2D basemap zooming standards.

## Contribution

- Zoom in with `=` key press.

## Test Plan

```
yarn start
```
