### PR TITLE
Zoom out with underscore key

### DIFF
--- a/src/component/keyboard/KeyZoomHandler.ts
+++ b/src/component/keyboard/KeyZoomHandler.ts
@@ -61,6 +61,7 @@ export class KeyZoomHandler extends HandlerBase<KeyboardConfiguration> {
                             delta = 1;
                             break;
                         case "-":
+                        case "_":
                             delta = -1;
                             break;
                         default:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

- Mimic basemap behaviors by allowing zoom in with `+` and `=` and zoom out with `-` and `_`.
- Always zoom 1 level.

## Contribution

Add zoom out for `_` key.

## Test Plan

```
yarn build
yarn start
```