### PR TITLE
Handle camera fallback properly

### DIFF
--- a/src/api/provider/GraphConverter.ts
+++ b/src/api/provider/GraphConverter.ts
@@ -20,15 +20,21 @@ export type MeshParameters = {
     perspective: boolean;
 };
 
-export function convertCameraType(graphCameraType: string): string {
-    switch (graphCameraType) {
+type ProjectionModel = {
+    cameraType: string;
+    parameters: number[];
+}
+
+export function convertCameraType(cameraType: string, parameters: number[]): ProjectionModel {
+    switch (cameraType) {
         case "equirectangular":
         case "spherical":
-            return "spherical";
+            return {cameraType: "spherical", parameters};
+        case "perspective":
         case "fisheye":
-            return "fisheye";
+            return {cameraType, parameters};
         default:
-            return "perspective";
+            return {cameraType: "perspective", parameters: [0.85, 0, 0]};
     }
 }
 
@@ -150,8 +156,9 @@ export class GraphConverter {
     public spatialImage(
         source: GraphSpatialImageEnt)
         : SpatialImageEnt {
-        source.camera_type = convertCameraType(source.camera_type);
-        source.camera_parameters = source.camera_parameters ?? [];
+        const {cameraType, parameters} = convertCameraType(source.camera_type, source.camera_parameters);
+        source.camera_type = cameraType;
+        source.camera_parameters = parameters;
         source.merge_id = source.merge_cc ? source.merge_cc.toString() : null;
         source.private = null;
         const thumbUrl = source.camera_type === 'spherical' ?

--- a/test/api/provider/GraphConverter.test.ts
+++ b/test/api/provider/GraphConverter.test.ts
@@ -15,11 +15,36 @@ import {
 
 describe("convertCameraType", () => {
     test("should convert to supported types", () => {
-        expect(convertCameraType("spherical")).toBe("spherical");
-        expect(convertCameraType("equirectangular")).toBe("spherical");
-        expect(convertCameraType("fisheye")).toBe("fisheye");
-        expect(convertCameraType("perspective")).toBe("perspective");
-        expect(convertCameraType("not-supported")).toBe("perspective");
+        const equirectangular = convertCameraType("equirectangular", []);
+        expect(equirectangular.cameraType).toBe("spherical");
+
+        const spherical = convertCameraType("spherical", []);
+        expect(spherical.cameraType).toBe("spherical");
+
+        const fisheye = convertCameraType("fisheye", [0.5]);
+        expect(fisheye.cameraType).toBe("fisheye");
+        expect(fisheye.parameters.length).toBe(1);
+        expect(fisheye.parameters[0]).toBe(0.5);
+
+        const perspective = convertCameraType("perspective", [0.2, 0.3]);
+        expect(perspective.cameraType).toBe("perspective");
+        expect(perspective.parameters.length).toBe(2);
+        expect(perspective.parameters[0]).toBe(0.2);
+        expect(perspective.parameters[1]).toBe(0.3);
+
+        const incorrect = convertCameraType("not-supported", [0.4]);
+        expect(incorrect.cameraType).toBe("perspective");
+        expect(incorrect.parameters.length).toBe(3);
+        expect(incorrect.parameters[0]).toBe(0.85);
+        expect(incorrect.parameters[1]).toBe(0);
+        expect(incorrect.parameters[2]).toBe(0);
+
+        const empty = convertCameraType("", [0.4]);
+        expect(empty.cameraType).toBe("perspective");
+        expect(empty.parameters.length).toBe(3);
+        expect(empty.parameters[0]).toBe(0.85);
+        expect(empty.parameters[1]).toBe(0);
+        expect(empty.parameters[2]).toBe(0);
     });
 });
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to MapillaryJS here: https://github.com/mapillary/mapillary-js/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Contribution

Set camera parameters to default value properly when falling back to perspective projection type.

(If this PR adds or changes functionality, describe it here.)

## Test Plan

```
yarn build
yarn test
yarn start
```

Navigate to an image that has not yet been SfM reconstructed.
